### PR TITLE
README directory change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.3)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -255,6 +257,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ $ ruby --version  # Need version 2.4.0 or later
 ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin18]
 $ gem install bundler
 $ pwd
-/Users/awdeorio/src/eecs280/eecs281-setup
+/Users/awdeorio/src/eecs280/tutorials
 $ bundle install
 ```
 
 Every day usage:
 ```console
 $ pwd
-/Users/awdeorio/src/eecs280/eecs281-setup/docs
+/Users/awdeorio/src/eecs280/tutorials/docs
 $ bundle exec jekyll serve
 ```
 
 If you run into Jekyll errors, run `bundle update`:
 ```console
 $ pwd
-/Users/awdeorio/src/eecs280/eecs281-setup
+/Users/awdeorio/src/eecs280/tutorials
 $ bundle update --all
 ```
 


### PR DESCRIPTION
1. Updated Gemfile.lock as instructed in README
2. Fixed README directory from "eecs281-setup" to "tutorials"

Note: this is a very minor pr meant as git/github practice for future contributions to the project.