### PR TITLE
Add getopt setup instructions for VS + boilerplate getopt code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,4 +263,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.22
+   2.3.26

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -14,8 +14,6 @@ This tutorial will help you set up an EECS 281 project using the EECS 280 tutori
       ```
       p0-hello/p0-hello/main.cpp
       ```
-- [ ] get opt starter code
-- [ ] get opt work around on Visual Studio
 - [ ] Configure visual debugger for CLI args and opts
 
 ## OS and tool installs
@@ -82,6 +80,40 @@ If you've used Visual Studio on your computer before, start the tutorial at the 
 
 If Visual Studio is new to you or new to your computer, start at the [beginning](https://eecs280staff.github.io/p1-stats/setup_visualstudio.html).  Stop after you've completed the [Add existing files](https://eecs280staff.github.io/p1-stats/setup_visualstudio.html#add-existing-files) section.
 
+### Getopt Setup
+
+Next, we will make sure to add the `getopt` library to Visual Studio. `getopt` is a C/C++ library used to process command line arguments, and its the library that we will be using in EECS 281. While the other IDEs contain of version of `getopt` in their compiler, Visual Studio does not.
+
+First, please download the `getopt.c` file [here](https://drive.google.com/file/d/0B4peex7_GmM7a3pEMW5IWkc2QlU/view?usp=sharing&resourcekey=0-YcGPldn2k_v7dE1iPznlBA) and the `getopt.h` file [here](https://drive.google.com/file/d/0B4peex7_GmM7TFg0NmQyT3J2WkU/view?usp=sharing&resourcekey=0-vbMAgHMzsnI6WiKZOjUONg).
+
+The `getopt.c` file is simple to use: merely put a copy of `getopt.c` in each project that needs it. When you turn in your project, do NOT make `getopt.c` part of your tarball (the Makefile that we give you will not include `getopt.c` in the tarballs).
+
+Next, we will need to make sure that `getopt.h` is accessible to Visual Studio. There are two ways to do this:
+
+1. Place `getopt.h` in Visual Studio include folder (**Preferred**)
+Put the `getopt.h` file inside one of the standard Visual Studio include folders. For Visual Studio 2022 Community, this folder is usually located in:
+```
+C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include
+```
+
+If you’re using a different version of VS (such as Community 2019), the location might be slightly different:
+```
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\VS\include
+```
+
+This location is usually locked and can only be accessed if you are “Administrator”.
+
+Open your file explorer and find the appropriate location shown above by starting at “This PC” (in the bottom left), and paste the file.
+
+You have successfully included `getopt.h` into the Visual Studio include folder, and you will simply need to `#include <getopt.h>` in every project that you do.
+
+2. Place `getopt.h` inside Project Directory
+Put `getopt.h` inside your project folder, and `#include "getopt.h"` in every file where you use `getopt`.
+
+When you pack up your project to test on CAEN or submit, you have to change your include statement to <getopt.h>, as the Autograder/CAEN will be using the built in library, and not the files provided in the project directory. You should also NOT include getopt.h as part of your submission tarball.
+
+``Note:`` The big problem with this solution is that if you forget to change from double quotes to angle quotes, your project will fail to compile when you submit, and waste time (and possibly a submit for the day).
+
 ### Xcode
 If you've used Xcode on your computer before, start the tutorial at the [Create a project](https://eecs280staff.github.io/p1-stats/setup_xcode.html#create-a-project) section.
 
@@ -130,10 +162,53 @@ hello world!
 ```
 
 ## Parsing command line arguments and options
-Edit your main program (e.g., `main.cpp`) to parse command line options and print them.
+Edit your main program (e.g., `main.cpp`) to parse command line options and print them. 
+
+``Note:`` If you are using Visual Studio, please make sure that you have setup `getopt` [here](#getopt-setup)
+
 
 ```c++
-// FIXME getopt boiler plate goes here
+// TODO: Finish this function, look for the individual TODO comments internally.
+// Process the command line; the only thing we need to return is the mode
+// when the user specifies the -m/--mode option.
+string getMode(int argc, char * argv[]) {
+  bool modeSpecified = false;
+  string mode;
+
+  // These are used with getopt_long()
+  opterr = false; // Let us handle all error output for command line options
+  int choice;
+  int option_index = 0;
+  option long_options[] = {
+      {"required", required_argument, nullptr, 'r'},
+      {"no_arg", no_argument, nullptr, 'n'},
+      { nullptr, 0, nullptr, '\0' }
+  };
+
+  // TODO: Fill in the double quotes, to match the mode and help options.
+  while ((choice = getopt_long(argc, argv, "r:n", long_options, &option_index)) != -1) {
+    switch (choice) {
+      case 'r':
+        cout << "The required argument flag was passed in with argument: " << optarg;
+        break;
+
+      case 'o':
+        cout << "The no argument flag was passed in.";
+        break;
+
+      default:
+        cerr << "Error: invalid option" << endl;
+        exit(1);
+  } // switch
+} // while
+
+if (!modeSpecified) {
+cerr << "Error: no mode specified" << endl;
+exit(1);
+} // if
+
+return mode;
+} // getMode()
 ```
 {: data-title="main.cpp" }
 

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -90,29 +90,32 @@ The `getopt.c` file is simple to use: merely put a copy of `getopt.c` in each pr
 
 Next, we will need to make sure that `getopt.h` is accessible to Visual Studio. There are two ways to do this:
 
-1. Place `getopt.h` in Visual Studio include folder (**Preferred**)
-Put the `getopt.h` file inside one of the standard Visual Studio include folders. For Visual Studio 2022 Community, this folder is usually located in:
-```
-C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include
-```
+1. Place `getopt.h` in Visual Studio include folder (**Preferred**)\
+    Put the `getopt.h` file inside one of the standard Visual Studio include folders. For Visual Studio 2022 Community, this folder is usually located in:
+    ``
+    C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include
+    ``
 
-If you’re using a different version of VS (such as Community 2019), the location might be slightly different:
-```
-C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\VS\include
-```
+    If you’re using a different version of VS (such as Community 2019), the location might be slightly different:
+    ``
+    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\VS\include
+    ``
 
-This location is usually locked and can only be accessed if you are “Administrator”.
+    This location is usually locked and can only be accessed if you are “Administrator”.
 
-Open your file explorer and find the appropriate location shown above by starting at “This PC” (in the bottom left), and paste the file.
+    Open your file explorer and find the appropriate location shown above by starting at “This PC” (in the bottom left), and paste the file.
 
-You have successfully included `getopt.h` into the Visual Studio include folder, and you will simply need to `#include <getopt.h>` in every project that you do.
+    You have successfully included `getopt.h` into the Visual Studio include folder, and you will simply need to `#include <getopt.h>` in every project that you do.
 
-2. Place `getopt.h` inside Project Directory
-Put `getopt.h` inside your project folder, and `#include "getopt.h"` in every file where you use `getopt`.
+2. Place `getopt.h` inside Project Directory\
+   Put `getopt.h` inside your project folder, and `#include "getopt.h"` in every file where you use `getopt`.
 
-When you pack up your project to test on CAEN or submit, you have to change your include statement to <getopt.h>, as the Autograder/CAEN will be using the built in library, and not the files provided in the project directory. You should also NOT include getopt.h as part of your submission tarball.
+   When you pack up your project to test on CAEN or submit, you have to change your include statement to <getopt.h>, as the Autograder/CAEN will be using the built in library, and not the files provided in the project directory. You should also NOT include getopt.h as part of your submission tarball.
 
-``Note:`` The big problem with this solution is that if you forget to change from double quotes to angle quotes, your project will fail to compile when you submit, and waste time (and possibly a submit for the day).
+    <div class="primer-spec-callout warning" markdown="1">
+    **Note:** The big problem with this solution is that if you forget to change from double quotes to angle quotes, your project will fail to compile when you submit, and waste time (and possibly a submit for the day).
+    </div>
+
 
 ### Xcode
 If you've used Xcode on your computer before, start the tutorial at the [Create a project](https://eecs280staff.github.io/p1-stats/setup_xcode.html#create-a-project) section.
@@ -164,9 +167,9 @@ hello world!
 ## Parsing command line arguments and options
 Edit your main program (e.g., `main.cpp`) to parse command line options and print them. 
 
-``Note:`` If you are using Visual Studio, please make sure that you have setup `getopt` [here](#getopt-setup)
+``Note: If you are using Visual Studio, please make sure that you have setup `getopt` [here](#getopt-setup)``
 
-
+A sample copy of the code required for `getopt` to work can be found below:
 ```c++
 // TODO: Finish this function, look for the individual TODO comments internally.
 // Process the command line; the only thing we need to return is the mode
@@ -212,7 +215,7 @@ return mode;
 ```
 {: data-title="main.cpp" }
 
-Compile and run.  You should see the sample command line arguments.  This might be a good time to change them to match your project spec.
+After adding the code to you file, you can now compile and run the program.  You should see the sample command line arguments.  This might be a good time to change them to match your project spec.
 ```console
 $ make main
 $ ./main FIXME


### PR DESCRIPTION
This commit adds instructions for using `getopt` to the eecs281 setup tutorial. Specifically, this commit does the following:
- Adds instructions for including `getopt` for Visual Studio.
- Provides access to `getopt.c` and `getopt.h` via a Google Drive link.
- Provides the boilerplate `getopt` code for students to use in all eecs281 projects.

Ideally, I'd like to remove Google Drive links, and allow students to access the files through a GitHub repository, but I'm still waiting for access to the EECS281 github repos.