### PR TITLE
Update setup_eecs281.md to include getopt instructions

### DIFF
--- a/docs/getopt.c
+++ b/docs/getopt.c
@@ -1,0 +1,572 @@
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+/*        $OpenBSD: getopt_long.c,v 1.23 2007/10/31 12:34:57 chl Exp $        */
+/*        $NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $        */
+
+/*
+* Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM Lcout OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*
+* Sponsored in part by the Defense Advanced Research Projects
+* Agency (DARPA) and Air Force Research Laboratory, Air Force
+* Materiel Command, USAF, under agreement number F39502-99-1-0512.
+*/
+/*-
+* Copyright (c) 2000 The NetBSD Foundation, Inc.
+* All rights reserved.
+*
+* This code is derived from software contributed to The NetBSD Foundation
+* by Dieter Baron and Thomas Klausner.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in the
+* documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+* ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; Lcout OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* PcoutIBILITY OF SUCH DAMAGE.
+*/
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdio.h>
+//#include <windows.h>
+
+#define        REPLACE_GETOPT                /* use this getopt as the system getopt(3) */
+
+#ifdef REPLACE_GETOPT
+int        opterr = 1;                /* if error message should be printed */
+int        optind = 1;                /* index into parent argv vector */
+int        optopt = '?';                /* character checked for validity */
+#undef        optreset                /* see getopt.h */
+#define        optreset                __mingw_optreset
+int        optreset;                /* reset getopt */
+char *optarg;                /* argument associated with option */
+#endif
+
+#define PRINT_ERROR        ((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE        0x01        /* permute non-options to the end of argv */
+#define FLAG_ALLARGS        0x02        /* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY        0x04        /* operate as getopt_long_only */
+
+/* return values */
+#define        BADCH                (int)'?'
+#define        BADARG                ((*options == ':') ? (int)':' : (int)'?')
+#define        INORDER         (int)1
+
+#ifndef __CYGWIN__
+#define __progname __argv[0]
+#else
+extern char __declspec(dllimport) *__progname;
+#endif
+
+#ifdef __CYGWIN__
+static char EMSG[] = "";
+#else
+#define        EMSG                ""
+#endif
+
+static int getopt_internal(int, char * const *, const char *,
+	const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+	const struct option *, int *, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1; /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static void
+_vwarnx(const char *fmt, va_list ap)
+{
+	(void)fprintf(stderr, "%s: ", __progname);
+	if (fmt != NULL)
+		(void)vfprintf(stderr, fmt, ap);
+	(void)fprintf(stderr, "\n");
+}
+
+static void
+warnx(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	_vwarnx(fmt, ap);
+	va_end(ap);
+}
+
+/*
+* Compute the greatest common divisor of a and b.
+*/
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+* Exchange the block from nonopt_start to nonopt_end with the block
+* from nonopt_end to opt_end (keeping the same order of arguments
+* in each block).
+*/
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	* compute lengths of blocks and number and size of cycles
+	*/
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end + i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **)nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+* parse_long_options --
+*        Parse long options in argc/argv argument vector.
+* Returns -1 if short_too is set and the option does not match long_options.
+*/
+static int
+parse_long_options(char * const *nargv, const char *options,
+const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, ambiguous, match;
+
+#define IDENTICAL_INTERPRETATION(_x, _y) \
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg && \
+	long_options[(_x)].flag == long_options[(_y)].flag && \
+	long_options[(_x)].val == long_options[(_y)].val)
+
+	current_argv = place;
+	match = -1;
+	ambiguous = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	}
+	else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+			current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			ambiguous = 0;
+			break;
+		}
+		/*
+		* If this is a known short option, don't allow
+		* a partial match of a single character.
+		*/
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)        /* partial match */
+			match = i;
+		else if (!IDENTICAL_INTERPRETATION(i, match))
+			ambiguous = 1;
+	}
+	if (ambiguous) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len,
+			current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {                /* option found */
+		if (long_options[match].has_arg == no_argument
+			&& has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				current_argv);
+			/*
+			* XXX: GNU sets optopt to val regardless of flag
+			*/
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+			long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+				required_argument) {
+				/*
+				* optional argument doesn't use next nargv
+				*/
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+			&& (optarg == NULL)) {
+			/*
+			* Missing argument; leading ':' indicates no error
+			* should be generated.
+			*/
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				current_argv);
+			/*
+			* XXX: GNU sets optopt to val regardless of flag
+			*/
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	}
+	else {                        /* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	}
+	else
+		return (long_options[match].val);
+#undef IDENTICAL_INTERPRETATION
+}
+
+/*
+* getopt_internal --
+*        Parse argc/argv argument vector. Called by user level routines.
+*/
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+const struct option *long_options, int *idx, int flags)
+{
+	char *oli;                                /* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	* XXX Some GNU programs (like cvs) set optind to 0 instead of
+	* XXX using optreset. Work around this braindamage.
+	*/
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	* Disable GNU extensions if POSIXLY_CORRECT is set or options
+	* string begins with a '+'.
+	*
+	* CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
+	* optreset != 0 for GNU compatibility.
+	*/
+	if (posixly_correct == -1 || optreset != 0)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {                /* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) { /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+					optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				* If we skipped non-options, set optind
+				* to the first of them.
+				*/
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+			(place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;                /* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				* GNU extension:
+				* return non-option as argument to option 1
+				*/
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				* If no permutation wanted, stop parsing
+				* at first non-option.
+				*/
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+					optind, nargv);
+				nonopt_start = optind -
+					(nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		* If we have "-" do nothing, if "--" we are done.
+		*/
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			* We found an option (--), so if we skipped
+			* non-options, we have to permute.
+			*/
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+					optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	* Check long options if:
+	* 1) we were passed some
+	* 2) the arg is not just "-"
+	* 3) either the arg starts with -- we are getopt_long_only()
+	*/
+	if (long_options != NULL && place != nargv[optind] &&
+		(*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;                /* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;                /* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+			idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+		(optchar == (int)'-' && *place != '\0') ||
+		(oli = strchr(options, optchar)) == NULL) {
+		/*
+		* If the user specified "-" and '-' isn't listed in
+		* options, return -1 (non-option) as per POSIX.
+		* Otherwise, it is an unknown option character (or ':').
+		*/
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)                        /* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {        /* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		}
+		else                                /* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+			idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {                        /* doesn't take argument */
+		if (!*place)
+			++optind;
+	}
+	else {                                /* takes (optional) argument */
+		optarg = NULL;
+		if (*place)                        /* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {        /* arg not optional */
+			if (++optind >= nargc) {        /* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			}
+			else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+#ifdef REPLACE_GETOPT
+/*
+* getopt --
+*        Parse argc/argv argument vector.
+*
+* [eventually this will replace the BSD getopt]
+*/
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	* We don't pass FLAG_PERMUTE to getopt_internal() since
+	* the BSD getopt(3) (unlike GNU) has never done this.
+	*
+	* Furthermore, since many privileged programs call getopt()
+	* before dropping privileges it makes sense to keep things
+	* as simple (and bug-free) as pcoutible.
+	*/
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+#endif /* REPLACE_GETOPT */
+
+/*
+* getopt_long --
+*        Parse argc/argv argument vector.
+*/
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+		FLAG_PERMUTE));
+}
+
+/*
+* getopt_long_only --
+*        Parse argc/argv argument vector.
+*/
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+		FLAG_PERMUTE | FLAG_LONGONLY));
+}

--- a/docs/getopt.h
+++ b/docs/getopt.h
@@ -1,0 +1,93 @@
+#ifndef __GETOPT_H__
+/**
+* DISCLAIMER
+* This file has no copyright assigned and is placed in the Public Domain.
+* This file is a part of the w64 mingw-runtime package.
+*
+* The w64 mingw-runtime package and its code is distributed in the hope that it
+* will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR
+* IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to
+* warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+#define __GETOPT_H__
+
+/* All the headers include this file. */
+#include <crtdefs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    extern int optind;		/* index of first non-option in argv      */
+    extern int optopt;		/* single option character, as parsed     */
+    extern int opterr;		/* flag to enable built-in diagnostics... */
+    /* (user may set to zero, to suppress)    */
+
+    extern char *optarg;		/* pointer to argument of current option  */
+
+    extern int getopt(int nargc, char * const *nargv, const char *options);
+
+#ifdef _BSD_SOURCE
+    /*
+    * BSD adds the non-standard `optreset' feature, for reinitialisation
+    * of `getopt' parsing.  We support this feature, for applications which
+    * proclaim their BSD heritage, before including this header; however,
+    * to maintain portability, developers are advised to avoid it.
+    */
+# define optreset  __mingw_optreset
+    extern int optreset;
+#endif
+#ifdef __cplusplus
+}
+#endif
+/*
+* POSIX requires the `getopt' API to be specified in `unistd.h';
+* thus, `unistd.h' includes this header.  However, we do not want
+* to expose the `getopt_long' or `getopt_long_only' APIs, when
+* included in this manner.  Thus, close the standard __GETOPT_H__
+* declarations block, and open an additional __GETOPT_LONG_H__
+* specific block, only when *not* __UNISTD_H_SOURCED__, in which
+* to declare the extended API.
+*/
+#endif /* !defined(__GETOPT_H__) */
+
+#if !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__)
+#define __GETOPT_LONG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    struct option		/* specification for a long form option...	*/
+    {
+        const char *name;		/* option name, without leading hyphens */
+        int         has_arg;		/* does it take an argument?		*/
+        int        *flag;		/* where to save its status, or NULL	*/
+        int         val;		/* its associated status value		*/
+    };
+
+    enum    		/* permitted values for its `has_arg' field...	*/
+    {
+        no_argument = 0,      	/* option never takes an argument	*/
+        required_argument,		/* option always requires an argument	*/
+        optional_argument		/* option may take an argument		*/
+    };
+
+    extern int getopt_long(int nargc, char * const *nargv, const char *options, const struct option *long_options, int *idx);
+    extern int getopt_long_only(int nargc, char * const *nargv, const char *options, const struct option *long_options, int *idx);
+    /*
+    * Previous MinGW implementation had...
+    */
+#ifndef HAVE_DECL_GETOPT
+    /*
+    * ...for the long form API only; keep this for compatibility.
+    */
+# define HAVE_DECL_GETOPT	1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -14,8 +14,6 @@ This tutorial will help you set up an EECS 281 project using the EECS 280 tutori
       ```
       p0-hello/p0-hello/main.cpp
       ```
-- [ ] get opt starter code
-- [ ] get opt work around on Visual Studio
 - [ ] Configure visual debugger for CLI args and opts
 
 ## OS and tool installs
@@ -82,6 +80,42 @@ If you've used Visual Studio on your computer before, start the tutorial at the 
 
 If Visual Studio is new to you or new to your computer, start at the [beginning](https://eecs280staff.github.io/p1-stats/setup_visualstudio.html).  Stop after you've completed the [Add existing files](https://eecs280staff.github.io/p1-stats/setup_visualstudio.html#add-existing-files) section.
 
+#### Getopt Setup
+
+Next, we will make sure to add the `getopt` library to Visual Studio. `getopt` is a C/C++ library used to process command line arguments, and its the library that we will be using in EECS 281. While the other IDEs contain of version of `getopt` in their compiler, Visual Studio does not.
+
+First, please download the `getopt.c` file <a href="/getopt.c" download>here</a> and the `getopt.h` file  <a href="/getopt.h" download>here</a>.
+
+The `getopt.c` file is simple to use: merely put a copy of `getopt.c` in each project that needs it. When you turn in your project, do NOT make `getopt.c` part of your tarball (the Makefile that we give you will not include `getopt.c` in the tarballs).
+
+Next, we will need to make sure that `getopt.h` is accessible to Visual Studio. There are two ways to do this:
+
+1. Place `getopt.h` in Visual Studio include folder (**Preferred**)
+    Put the `getopt.h` file inside one of the standard Visual Studio include folders. For Visual Studio 2022 Community, this folder is usually located in:
+    ```
+    C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include
+    ```
+
+    If you’re using a different version of VS (such as Community 2019), the location might be slightly different:
+    ```
+    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\VS\include
+    ```
+
+    This location is usually locked and can only be accessed if you are “Administrator”.
+
+    Open your file explorer and find the appropriate location shown above by starting at “This PC” (in the bottom left), and paste the file.
+
+    You have successfully included `getopt.h` into the Visual Studio include folder, and you will simply need to `#include <getopt.h>` in every project that you do.
+
+2. Place `getopt.h` inside Project Directory
+    Put `getopt.h` inside your project folder, and `#include "getopt.h"` in every file where you use `getopt`.
+
+    When you pack up your project to test on CAEN or submit, you have to change your include statement to <getopt.h>, as the Autograder/CAEN will be using the built in library, and not the files provided in the project directory. You should also NOT include getopt.h as part of your submission tarball.
+
+    <div class="primer-spec-callout info" markdown="1">
+    Note: The big problem with this solution is that if you forget to change from double quotes to angle quotes, your project will fail to compile when you submit, and waste time (and possibly a submit for the day).
+    </div>
+
 ### Xcode
 If you've used Xcode on your computer before, start the tutorial at the [Create a project](https://eecs280staff.github.io/p1-stats/setup_xcode.html#create-a-project) section.
 
@@ -132,12 +166,51 @@ hello world!
 ## Parsing command line arguments and options
 Edit your main program (e.g., `main.cpp`) to parse command line options and print them.
 
+``Note: If you are using Visual Studio, please make sure that you have setup `getopt` [here](#getopt-setup)``
+
+A sample copy of the code required for `getopt` to work can be found below:
+
 ```c++
-// FIXME getopt boiler plate goes here
+// TODO: Finish this function, look for the individual TODO comments internally.
+// Process the command line; the only thing we need to return is the mode
+// when the user specifies the -m/--mode option.
+string getMode(int argc, char * argv[]) {
+  bool modeSpecified = false;
+  string mode;
+  // These are used with getopt_long()
+  opterr = false; // Let us handle all error output for command line options
+  int choice;
+  int option_index = 0;
+  option long_options[] = {
+      {"required", required_argument, nullptr, 'r'},
+      {"no_arg", no_argument, nullptr, 'n'},
+      { nullptr, 0, nullptr, '\0' }
+  };
+  // TODO: Fill in the double quotes, to match the mode and help options.
+  while ((choice = getopt_long(argc, argv, "r:n", long_options, &option_index)) != -1) {
+    switch (choice) {
+      case 'r':
+        cout << "The required argument flag was passed in with argument: " << optarg;
+        break;
+      case 'o':
+        cout << "The no argument flag was passed in.";
+        break;
+      default:
+        cerr << "Error: invalid option" << endl;
+        exit(1);
+  } // switch
+} // while
+if (!modeSpecified) {
+cerr << "Error: no mode specified" << endl;
+exit(1);
+} // if
+return mode;
+} // getMode()
 ```
 {: data-title="main.cpp" }
 
-Compile and run.  You should see the sample command line arguments.  This might be a good time to change them to match your project spec.
+After adding the code to you file, you can now compile and run the program. You should see the sample command line arguments. This might be a good time to change them to match your project spec.
+
 ```console
 $ make main
 $ ./main FIXME

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -149,12 +149,31 @@ EECS281 Advanced Makefile Help
 Edit these three lines in the Makefile.  Your values might be different, check the project spec for required file names.
 ```make
 UNIQNAME = not_awdeorio
+# .. 
+IDENTIFIER  = not_a_valid_identifier
 # ...
 EXECUTABLE = main
 # ...
-PROJECTFILE = main.cpp
 ```
 {: data-title="Makefile" }
+
+If your main file is not one of the following forms, where EXECUTABLE is the name of the executable specified in the Makefile:
+  - `main.cpp`
+  - `project0.cpp`
+  - `project1.cpp`
+  - `project2.cpp`
+  - `project3.cpp`
+  - `project4.cpp`
+  - `EXECUTEABLE.cpp`
+
+
+You will need to update the following line as well:
+```make
+PROJECTFILE = main_file_name.cpp
+```
+
+If your project has additional dependencies, please update the dependencies section at the bottom of the Makefile, as well.
+
 
 You should be able to compile and run your main function.
 ```console

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -54,6 +54,12 @@ For reference, this is the version of Visual Studio we're using in this example.
 
 <img src="images/visualstudio030.png" width="512px" />
 
+### Getopt setup
+<div class="primer-spec-callout warning" markdown="1">
+This sections is only required for EECS 281 students. If you are a EECS 280 student, please skip this section.
+</div>
+
+Please follow the guide [here](/setup_eecs281.md#getopt-setup) to setup
 
 # Create a project
 A Visual Studio project contains the files and information to build your software.  In EECS 280, you'll eventually create one Visual Studio project for each EECS 280 project.

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -56,10 +56,10 @@ For reference, this is the version of Visual Studio we're using in this example.
 
 ### Getopt setup
 <div class="primer-spec-callout warning" markdown="1">
-This sections is only required for EECS 281 students. If you are a EECS 280 student, please skip this section.
+This section is only required for EECS 281 students. If you are a EECS 280 student, please skip this section.
 </div>
 
-Please follow the guide [here](/setup_eecs281.md#getopt-setup) to setup
+Please follow the guide [here](/setup_eecs281.md#getopt-setup) to setup Visual Studio for `getopt`.
 
 # Create a project
 A Visual Studio project contains the files and information to build your software.  In EECS 280, you'll eventually create one Visual Studio project for each EECS 280 project.


### PR DESCRIPTION
This commit adds instructions for using getopt to the eecs281 setup tutorial. Specifically, this commit does the following:

- Adds instructions for including getopt for Visual Studio.
- Provides access to getopt.c and getopt.h
- Provides the boilerplate getopt code for students to use in all eecs281 projects.
- Updates `setup_visualstudio.md` to inform students that they must follow the steps in the `setup_eecs281.md` tutorial
- Updates instructions for editing the Makefile
