### PR TITLE
[Primer Spec] Fix PDF URL in Spec Previews

### DIFF
--- a/.github/workflows/spec_preview.yml
+++ b/.github/workflows/spec_preview.yml
@@ -4,11 +4,12 @@ name: Generate spec preview
 
 # Define conditions for when to run this action.
 # We'll only generate spec previews on Pull Requests, and only when the
-# `docs/` directory has been modified.
+# `docs/` directory or this workflow has been modified.
 on:
   pull_request:
     paths:
       - "docs/**"
+      - ".github/workflows/spec_preview.yml"
 
 # A workflow run is made up of one or more jobs. Each job has an id.
 # This workflow has only one job that builds and uploads the spec preview.

--- a/.github/workflows/spec_preview.yml
+++ b/.github/workflows/spec_preview.yml
@@ -31,6 +31,9 @@ jobs:
       # Docs: https://github.com/seshrs/build-primer-spec-action
       - name: 🛠 Build Primer Spec website
         uses: seshrs/build-primer-spec-action@v1
+        with:
+          # We won't be using GitHub Pages for the spec previews.
+          configure_github_pages: false
 
       # Upload the site to Primer Spec Preview and comment on the PR.
       # The Primer Spec Preview secret is stored as an encrypted repo or


### PR DESCRIPTION
## Context

I recently released [v1.9.0 of Primer Spec](https://github.com/eecs485staff/primer-spec/releases/tag/v1.9.0%2Bwn23) along with changes to [seshrs/build-primer-spec-action](https://github.com/seshrs/build-primer-spec-action). One of the new features is that Primer Spec will automatically generate a PDF version of every page in your website!

Unfortunately, we need to make a small change to the "spec previews" workflow to make the PR preview websites use the correct PDF URL.

I'll be making this change to all websites using [seshrs/upload-to-primer-spec-preview](https://github.com/seshrs/upload-to-primer-spec-preview).

## Validation

Visit any Primer Spec page in the [spec preview website for this PR](https://preview.sesh.rs/previews/eecs280staff/tutorials/55/). Click the "Download" button in the Topbar. The PDF file should download correctly.

Example page: https://preview.sesh.rs/previews/eecs280staff/tutorials/55/setup_vscode.html