### PR TITLE
Fix Broken Dependencies and Remove setup.md

### DIFF
--- a/docs/debugging_guide.md
+++ b/docs/debugging_guide.md
@@ -20,7 +20,7 @@ We also show several real examples drawn from course projects in EECS 280. In so
 
 If you need to get your debugger set up for the first time and configured to run your code, check out one of our IDE tutorials for instructions.
 
-| [VS Code](setup_vscode.html)| [Visual Studio](setup_visualstudio.html) | [Xcode](setup_xcode.html) | [Emacs](setup_emacs.html) |
+| [VS Code](setup_vscode.html) | [Visual Studio](setup_visualstudio.html) | [Xcode](setup_xcode.html) | [Emacs](setup_emacs.html) |
 
 ## Inspect Program State
 

--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -44,19 +44,43 @@ $ emacs main.cpp &
 
 
 # Prerequisites
-At this point, you should already have a folder for your project ([instructions](setup.md#create-a-folder)).  Your folder location might be different.  You should have downloaded and unpacked the starter files already ([instructions](setup.md#download-and-unpack-starter-files)).
-```console
-$ pwd
-/Users/awdeorio/src/eecs280/p1-stats
-$ ls
-Makefile      main_test.out.correct  p1_library.h           stats_tests.cpp
-README.md     main_test_data.tsv     stats.h
-main_test.in  p1_library.cpp         stats_public_test.cpp
-```
-
 This tutorial uses command line tools.  If you haven't installed CLI tools on your machine yet, follow one of these tutorials first.
 
 | [macOS](setup_macos.html)| [Windows](setup_wsl.html) | [Linux](setup_wsl.html#install-cli-tools)
+
+Create a new folder for your project. Your folder location might be different.
+
+```console
+$ pwd
+/Users/awdeorio/src/eecs280
+$ mkdir p1-stats
+```
+
+Change into your new project directory. Use the terminal to download, unpack, and move the starter files into your project. Your URL or folder might be different.
+```console
+$ cd p1-stats
+$ wget https://eecs280staff.github.io/p1-stats/starter-files.tar.gz
+$ tar -xvzf starter-files.tar.gz
+$ mv starter-files/* .
+$ rm -rf starter-files starter-files.tar.gz
+```
+
+You should see your new files in your project directory.
+```console
+$ tree
+.
+├── Makefile
+├── main_test.in
+├── main_test.out.correct
+├── main_test_data.tsv
+├── p1_library.cpp
+├── p1_library.h
+├── stats.h
+├── stats_public_test.cpp
+└── stats_tests.cpp.starter
+```
+
+In the tutorial below, we'll show you how to use Emacs to create new files `stats.cpp` and `main.cpp`.
 
 
 # Restarting this tutorial

--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -48,40 +48,6 @@ This tutorial uses command line tools.  If you haven't installed CLI tools on yo
 
 | [macOS](setup_macos.html)| [Windows](setup_wsl.html) | [Linux](setup_wsl.html#install-cli-tools)
 
-Create a new folder for your project. Your folder location might be different.
-
-```console
-$ pwd
-/Users/awdeorio/src/eecs280
-$ mkdir p1-stats
-```
-
-Change into your new project directory. Use the terminal to download, unpack, and move the starter files into your project. Your URL or folder might be different.
-```console
-$ cd p1-stats
-$ wget https://eecs280staff.github.io/p1-stats/starter-files.tar.gz
-$ tar -xvzf starter-files.tar.gz
-$ mv starter-files/* .
-$ rm -rf starter-files starter-files.tar.gz
-```
-
-You should see your new files in your project directory.
-```console
-$ tree
-.
-├── Makefile
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
-├── p1_library.cpp
-├── p1_library.h
-├── stats.h
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
-```
-
-In the tutorial below, we'll show you how to use Emacs to create new files `stats.cpp` and `main.cpp`.
-
 
 # Restarting this tutorial
 If you tried using this tutorial in the past and want to "start clean", here's how to delete all Emacs configuration files.  This will not delete your code.  First, quit Emacs.
@@ -217,7 +183,39 @@ On Apple laptops, it's more ergonomic to map Command to Meta and Option to Super
 
 
 # Create a project
-Emacs doesn't require any special setup for a project.  In this section, we'll add some files to our directory.
+Emacs doesn't require any special setup for a project.
+
+Create a new folder for your project. Your folder location might be different.
+
+```console
+$ pwd
+/Users/awdeorio/src/eecs280
+$ mkdir p1-stats
+```
+
+Change into your new project directory. Use the terminal to download, unpack, and move the starter files into your project. Your URL or folder might be different.
+```console
+$ cd p1-stats
+$ wget https://eecs280staff.github.io/p1-stats/starter-files.tar.gz
+$ tar -xvzf starter-files.tar.gz
+$ mv starter-files/* .
+$ rm -rf starter-files starter-files.tar.gz
+```
+
+You should see your new files in your project directory.
+```console
+$ tree
+.
+├── Makefile
+├── main_test.in
+├── main_test.out.correct
+├── main_test_data.tsv
+├── p1_library.cpp
+├── p1_library.h
+├── stats.h
+├── stats_public_test.cpp
+└── stats_tests.cpp.starter
+```
 
 ## Add new files
 EECS 280 project 1 requires us to create two new files: `stats.cpp` and `main.cpp`.

--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -548,11 +548,6 @@ Of course Emacs has a dark mode. Add the following to your `init.el`.
 
 ```
 
-
-# Next steps
-[Return to the main set up tutorial.](setup.md#text-editor-and-debugger)
-
-
 # Acknowledgments
 Original document written by Andrew DeOrio awdeorio@umich.edu.
 

--- a/docs/setup_gdb.md
+++ b/docs/setup_gdb.md
@@ -46,7 +46,12 @@ $ gdb -tui stats_tests.exe
 
 
 # Prerequisites
-At this point, you should already have a folder for your project ([instructions](setup.html#create-a-folder)).  Your folder location might be different.  You should have downloaded and unpacked the starter files already ([instructions](setup.html#download-and-unpack-starter-files)).
+This tutorial uses command line tools.  If you haven't installed CLI tools on your machine yet, follow one of these tutorials first.
+
+| [macOS](setup_macos.html)| [Windows](setup_wsl.html) | [Linux](setup_wsl.html#install-cli-tools)
+
+We presume you've created a folder for your project, downloaded and unpacked the starter files, and created any new files with appropriate function stubs.
+
 ```console
 $ pwd
 /Users/awdeorio/src/eecs280/p1-stats
@@ -61,6 +66,11 @@ You should have function stubs in `stats.h` and `main.cpp`.  If you simply want 
 $ wget --no-clobber https://eecs280staff.github.io/tutorials/stats.cpp -O stats.cpp
 $ wget --no-clobber https://eecs280staff.github.io/tutorials/main.cpp -O main.cpp
 ```
+
+If you're not sure how to do this, you might find one of our IDE tutorials helpful. Walk through the tutorial up through the "Create a project" section.
+
+| [VS Code](setup_vscode.html) | [Visual Studio](setup_visualstudio.html) | [Xcode](setup_xcode.html) | [Emacs](setup_emacs.html) |
+
 
 
 # Install
@@ -509,11 +519,6 @@ Use the up arrow key to cycle through previously used commands.
 Use TAB completion to automatically complete the name of a command or a variable.
 
 Use Emacs keyboard shortcuts to enter and edit your current command.
-
-
-# Next steps
-[Return to the main set up tutorial.](setup.html#command-line-editor-and-debugger)
-
 
 
 # Pretty-printing STL Containers with `gdb`

--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -56,8 +56,12 @@ $ git status
 fatal: Not a git repository (or any of the parent directories): .git
 ```
 
-## Install
-You should already have `git` installed after completing the [Command line tools](setup.html#command-line-tools) tutorial.  Verify that `git` is installed.  Your version might be different.
+## Prerequisites
+This tutorial uses command line tools.  If you haven't installed CLI tools on your machine yet, follow one of these tutorials first.
+
+| [macOS](setup_macos.html)| [Windows](setup_wsl.html) | [Linux](setup_wsl.html#install-cli-tools)
+
+Verify that `git` is installed.  Your version might be different.
 ```console
 $ git --version
 git version 2.15.1

--- a/docs/setup_lldb.md
+++ b/docs/setup_lldb.md
@@ -70,7 +70,7 @@ If you're not sure how to do this, you might find one of our IDE tutorials helpf
 
 
 # Install
-This tutorial focuses on LLDB for macOS.  Your versions might be different.  You should already have `g++` and `lldb` installed from the main [macOS tutorial](setup.html#macos).
+This tutorial focuses on LLDB for macOS.  Your versions might be different.  You should already have `g++` and `lldb` installed from the main [macOS tutorial](setup_macos.html).
 ```console
 $ g++ --version
 Apple clang version 12.0.0 (clang-1200.0.32.28)

--- a/docs/setup_lldb.md
+++ b/docs/setup_lldb.md
@@ -40,8 +40,14 @@ $ lldb stats_tests.exe
 | `q` | quit |
 
 
+
 # Prerequisites
-At this point, you should already have a folder for your project ([instructions](setup.html#create-a-folder)).  Your folder location might be different.  You should have downloaded and unpacked the starter files already ([instructions](setup.html#download-and-unpack-starter-files)).
+This tutorial uses command line tools.  If you haven't installed CLI tools on your machine yet, follow one of these tutorials first.
+
+| [macOS](setup_macos.html)| [Windows](setup_wsl.html) | [Linux](setup_wsl.html#install-cli-tools)
+
+We presume you've created a folder for your project, downloaded and unpacked the starter files, and created any new files with appropriate function stubs.
+
 ```console
 $ pwd
 /Users/awdeorio/src/eecs280/p1-stats
@@ -55,6 +61,11 @@ You should have function stubs in `stats.h` and `main.cpp`.  If you simply want 
 ```console
 $ wget --no-clobber https://eecs280staff.github.io/tutorials/stats.cpp -O stats.cpp
 $ wget --no-clobber https://eecs280staff.github.io/tutorials/main.cpp -O main.cpp
+```
+
+If you're not sure how to do this, you might find one of our IDE tutorials helpful. Walk through the tutorial up through the "Create a project" section.
+
+| [VS Code](setup_vscode.html) | [Visual Studio](setup_visualstudio.html) | [Xcode](setup_xcode.html) | [Emacs](setup_emacs.html) |
 ```
 
 
@@ -311,10 +322,6 @@ Use the up and down arrow keys to cycle through previous commands similar to you
 Use TAB completion to automatically complete the name of a command or a variable.
 
 Use [Emacs](setup_emacs.html) keyboard shortcuts to enter and edit your current command.
-
-
-# Next steps
-[Return to the main set up tutorial.](setup.html#text-editor-and-debugger)
 
 
 # Acknowledgments

--- a/docs/setup_make.md
+++ b/docs/setup_make.md
@@ -186,11 +186,6 @@ $ make -j4 test
 ```
 {: data-variant="no-line-numbers" }
 
-
-# Next steps
-[Return to the main set up tutorial.](setup.html#makefiles)
-
-
 # Acknowledgments
 Original document written by Andrew DeOrio awdeorio@umich.edu.
 


### PR DESCRIPTION
We've had some discussion about removing `setup.md` (#53 and #54) since it is largely unnecessary.

I took at look at what this would require and found that many of the links back to `setup.md` (or equivalently, `setup.html`) were actually *already broken*, because a significant amount had been moved into the individual IDE tutorials (e.g. links back to `setup.html#create-a-folder` were going to a section that no longer exists). Making the main setup tutorial more lightweight is a good change, but a few straggler links to the old beefy one persisted.

A number of tutorials also finished with a section that instructed students to "return to the main setup tutorial". Some of these were broken because of recent changes, but I think all are best removed anyway since it's a maintenance burden to have the sequencing of tutorials encoded across many different `.md` files.

This PR does not go all the way in removing `setup.md` and leaves that to #53 or #54. (In theory, the main setup tutorial could still exist after merging this PR, but would just be a one-way front page and may be superseded by the work in one of those PRs.)