### PR TITLE
Visual Studio 2017 compile fixes

### DIFF
--- a/docs/xgetopt.h
+++ b/docs/xgetopt.h
@@ -218,7 +218,7 @@ static int parse_long_options(char * const *, const char *,
 static int gcd(int, int);
 static void permute_args(int, int, int, char * const *);
 
-static const char *place = EMSG; /* option letter processing */
+static char *place = EMSG; /* option letter processing */
 
 /* XXX: set optreset to 1 rather than these two */
 static int nonopt_start = -1; /* first non option argument (for permute) */
@@ -314,7 +314,7 @@ static int
 parse_long_options(char * const *nargv, const char *options,
 const struct option *long_options, int *idx, int short_too)
 {
-	const char *current_argv, *has_equal;
+	char *current_argv, *has_equal;
 	size_t current_argv_len;
 	int i, ambiguous, match;
 

--- a/docs/xgetopt.h
+++ b/docs/xgetopt.h
@@ -697,4 +697,4 @@ const struct option *long_options, int *idx)
 
 #endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */
 #endif /* ifndef __XGETOPT_H__ */
-#endif /* ifndef _WIN32 */
+#endif /* ifndef _MSC_VER */

--- a/docs/xgetopt.h
+++ b/docs/xgetopt.h
@@ -43,7 +43,7 @@ extern "C" {
     extern int opterr;		/* flag to enable built-in diagnostics... */
     /* (user may set to zero, to suppress)    */
 
-    extern char *optarg;		/* pointer to argument of current option  */
+    extern const char *optarg;		/* pointer to argument of current option  */
 
     extern int getopt(int nargc, char * const *nargv, const char *options);
 
@@ -182,7 +182,7 @@ int        optopt = '?';                /* character checked for validity */
 #undef        optreset                /* see getopt.h */
 #define        optreset                __mingw_optreset
 int        optreset;                /* reset getopt */
-char *optarg;                /* argument associated with option */
+const char *optarg;                /* argument associated with option */
 #endif
 
 #define PRINT_ERROR        ((opterr) && (*options != ':'))
@@ -215,7 +215,7 @@ static int parse_long_options(char * const *, const char *,
 static int gcd(int, int);
 static void permute_args(int, int, int, char * const *);
 
-static char *place = EMSG; /* option letter processing */
+static const char *place = EMSG; /* option letter processing */
 
 /* XXX: set optreset to 1 rather than these two */
 static int nonopt_start = -1; /* first non option argument (for permute) */
@@ -311,7 +311,7 @@ static int
 parse_long_options(char * const *nargv, const char *options,
 const struct option *long_options, int *idx, int short_too)
 {
-	char *current_argv, *has_equal;
+	const char *current_argv, *has_equal;
 	size_t current_argv_len;
 	int i, ambiguous, match;
 

--- a/docs/xgetopt.h
+++ b/docs/xgetopt.h
@@ -11,7 +11,7 @@
 * This file is adapted from from w64 mingw-runtime package's getopt.{h,c}.
 */
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <getopt.h>  // Linux et al.
 #else
 


### PR DESCRIPTION
Fixes to `xgetopt.h` to support Visual Studio 2017.  This supports the EECS 281 tutorial `getopt` library for EECS 281 students.  Contribution from Dave Paoletti.