### PR TITLE
Update wslu install pitfalls

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -250,7 +250,7 @@ On WSL (Windows), `wslview` opens a file or directory with the default applicati
   Your browser does not support the video tag.
 </video>
 
-<div class="primer-spec-callout warning" markdown="1">
+<div id="pitfall-install-wslview" class="primer-spec-callout warning" markdown="1">
 **WSL Pitfall:** You may need to install `wslu`, which includes `wslview` ([source](https://wslutiliti.es/wslu/install.html#ubuntu)).
 
 Check your Ubuntu version.
@@ -328,18 +328,7 @@ $ wslview ~/.bash_profile
 {: data-variant="no-line-numbers" }
 
 <div class="primer-spec-callout warning" markdown="1">
-**WSL Pitfall:** You may need to install `wslu`, which includes `wslview`.
-```console
-$ sudo apt install wslu
-```
-If this does not work, try running:
-```console
-$ sudo apt update
-$ sudo apt install ubuntu-wsl
-$ sudo add-apt-repository ppa:wslutilities/wslu
-$ sudo apt update
-$ sudo apt install wslu
-```
+**WSL Pitfall:** You may need to [install `wslview`](#pitfall-install-wslview).
 </div>
 
 Add this line.  Whenever you type `ls`, you'll actually get `ls --color`, which adds color.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,6 +255,15 @@ On WSL (Windows), `wslview` opens a file or directory with the default applicati
 ```console
 $ sudo apt install wslu
 ```
+If this does not work, try running:
+```console
+$ sudo apt update
+$ sudo apt install ubuntu-wsl
+$ sudo add-apt-repository ppa:wslutilities/wslu
+$ sudo apt update
+$ sudo apt install wslu
+```
+
 </div>
 
 ## Tips and Tricks
@@ -314,6 +323,14 @@ $ wslview ~/.bash_profile
 <div class="primer-spec-callout warning" markdown="1">
 **WSL Pitfall:** You may need to install `wslu`, which includes `wslview`.
 ```console
+$ sudo apt install wslu
+```
+If this does not work, try running:
+```console
+$ sudo apt update
+$ sudo apt install ubuntu-wsl
+$ sudo add-apt-repository ppa:wslutilities/wslu
+$ sudo apt update
 $ sudo apt install wslu
 ```
 </div>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -251,19 +251,26 @@ On WSL (Windows), `wslview` opens a file or directory with the default applicati
 </video>
 
 <div class="primer-spec-callout warning" markdown="1">
-**WSL Pitfall:** You may need to install `wslu`, which includes `wslview`.
+**WSL Pitfall:** You may need to install `wslu`, which includes `wslview` ([source](https://wslutiliti.es/wslu/install.html#ubuntu)).
+
+Check your Ubuntu version.
 ```console
-$ sudo apt install wslu
+$ lsb_release
+Description:    Ubuntu 20.04.1 LTS
 ```
-If this does not work, try running:
+
+Ubuntu 20.04 and earlier:
 ```console
 $ sudo apt update
-$ sudo apt install ubuntu-wsl
+$ sudo apt install ubuntu-wsl wslu
+```
+
+Ubuntu 22.04 and later:
+```console
 $ sudo add-apt-repository ppa:wslutilities/wslu
 $ sudo apt update
 $ sudo apt install wslu
 ```
-
 </div>
 
 ## Tips and Tricks

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,8 +255,8 @@ On WSL (Windows), `wslview` opens a file or directory with the default applicati
 
 Check your Ubuntu version.
 ```console
-$ lsb_release
-Description:    Ubuntu 20.04.1 LTS
+$ lsb_release -a
+Description:    Ubuntu 22.04 LTS
 ```
 
 Ubuntu 20.04 and earlier:


### PR DESCRIPTION
Based on Piazza post [@432](https://piazza.com/class/lbnv6k5pd0y6bz/post/432).
From [this link](https://wslutiliti.es/wslu/install.html#ubuntu), it appears some versions of Ubuntu require a different way of installing wslu (for wslview). The added commands are also taken from the link.
Unfortunately I do not have a Windows machine so am unable to test this, but it seemed to have worked for the student who posted on Piazza.