### PR TITLE
Simplify CodeLLDB input redirection

### DIFF
--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -441,6 +441,20 @@ To configure input redirection, edit `launch.json` ([docs](https://github.com/va
 ```
 {: data-title="launch.json" data-highlight="6" }
 
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** Make sure you're using the CodeLLDB extension.  You should see `lldb` in your `launch.json`.  If not, delete your `launch.json` and try the [compile and run](#compile-and-run) section again.
+
+```json
+{
+    "configurations": [
+        {
+            "type": "lldb",
+            ...
+```
+{: data-title="launch.json" data-highlight="4" }
+
+</div>
+
 ### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection for EECS 280 project 1.

--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -433,19 +433,13 @@ To configure input redirection, edit `launch.json`.
         {
             ...
             "program": "${workspaceFolder}/main.exe",
-            ...
-            "MIMode": "lldb",
-            "setupCommands": [
-                {
-                    "text": "settings set target.input-path main_test.in"
-                }
-            ]
+            "stdio": ["main_test.in", null, null],
             ...
         }
     ]
 }
 ```
-{: data-title="launch.json" data-highlight="10" }
+{: data-title="launch.json" data-highlight="6" }
 
 ### Arguments and options
 <div class="primer-spec-callout info" markdown="1">

--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -426,7 +426,7 @@ To configure input redirection, edit `launch.json`.
 
 #### macOS `launch.json` changes
 
-To configure input redirection, edit `launch.json`.
+To configure input redirection, edit `launch.json` ([docs](https://github.com/vadimcn/vscode-lldb/blob/master/MANUAL.md#stdio-redirection)).
 ```json
 {
     "configurations": [


### PR DESCRIPTION
Use the simpler version of input redirection for the Code LLDB extension on macOS.

### Validation
Check if this works on a mac with CodeLLDB and EECS 280 Project 1 main.exe with input redirection.