### PR TITLE
Fix a link error

### DIFF
--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -173,7 +173,7 @@ main.exe.dSYM/Contents/Resources/DWARF/main.exe
 ...
 ```
 
-First, double-check your `.gitignore`.  Go [back](#create-a-local-repository) if necessary and re-download it.
+First, double-check your `.gitignore`.  Go [back](#add-a-gitignore-file) if necessary and re-download it.
 ```console
 $ head .gitignore
 # This is a sample .gitignore file that's useful for C++ projects.

--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -173,7 +173,7 @@ main.exe.dSYM/Contents/Resources/DWARF/main.exe
 ...
 ```
 
-First, double-check your `.gitignore`.  Go [back](http://localhost:4000/setup_git.html#create-a-local-repository) if necessary and re-download it.
+First, double-check your `.gitignore`.  Go [back](#create-a-local-repository) if necessary and re-download it.
 ```console
 $ head .gitignore
 # This is a sample .gitignore file that's useful for C++ projects.


### PR DESCRIPTION
There was a stale development link in the Git tutorial.