### PR TITLE
Add prompts from ssh-keygen

### DIFF
--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -91,14 +91,14 @@ If you don't have an SSH key, generate one.
 ```console
 $ ssh-keygen -t ed25519 -C "your_email@example.com"
 Generating public/private ed25519 key pair.
-Enter file in which to save the key (/home/<your_username>/.ssh/id_ed25519): 
+Enter file in which to save the key (/home/awdeorio/.ssh/id_ed25519): 
 ```
 Press Enter to save the file to the default location.
 
 We recommend entering a passphrase in the following prompts.
 ```console
-Enter passphrase (empty for no passphrase): 
-Enter same passphrase again: 
+Enter passphrase (empty for no passphrase): <put your passphrase here!>
+Enter same passphrase again: <put your passphrase here!>
 ...
 Your public key has been saved in /Users/awdeorio/.ssh/id_ed25519.pub
 ```

--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -87,9 +87,18 @@ id_ed25519.pub
 ...
 ```
 
-If you don't have an SSH key, generate one.  Accept the default file location.  We recommend entering a passphrase.
+If you don't have an SSH key, generate one.  
 ```console
 $ ssh-keygen -t ed25519 -C "your_email@example.com"
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/home/<your_username>/.ssh/id_ed25519): 
+```
+Press Enter to save the file to the default location.
+
+We recommend entering a passphrase in the following prompts.
+```console
+Enter passphrase (empty for no passphrase): 
+Enter same passphrase again: 
 ...
 Your public key has been saved in /Users/awdeorio/.ssh/id_ed25519.pub
 ```


### PR DESCRIPTION
Add text and sample CLI output to clarify that students should see prompts after running the ssh-keygen command and that they should accept the default path (first prompt) and set up a passphrase (second and third prompts). 