### PR TITLE
EECS 281 Tutorial compile with debug symbols

### DIFF
--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -61,19 +61,10 @@ EXECUTABLE = main
 
 If your project has additional dependencies, update the dependencies section at the bottom of the `Makefile`.
 
-You should be able to compile and run your main file.
-
-If you want to compile a optimized release build use the `make` command:
-```console
-$ make
-$ ./main
-hello world!
-```
-
-If you want to compile a debug build use the `make debug` command which includes the debug symbols:
+You should be able to compile and run your main file with debug symbols.
 ```console
 $ make debug
-$ ./main
+$ ./main_debug
 hello world!
 ```
 

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -77,7 +77,6 @@ $ ./main
 hello world!
 ```
 
-
 ## Arguments and options
 Edit your main program (e.g., `main.cpp`) to parse command line options and print them.  Copy this sample code.
 

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -9,14 +9,12 @@ EECS 281 Project Setup
 
 This tutorial walks through EECS 281 project setup using EECS 280 tutorials.
 
+VS Code works great for EECS 281 projects.  Just ask one of the IAs or GSIs who use VS Code if you need help.
+
 ## Visual debugger
 Set up your project in your visual debugger.  We'll use the project name `p1-stats` in this example, but your project name may be different.  If your project has starter files, you'll need the link from the project spec.
 
 | [VS Code Tutorial](https://eecs280staff.github.io/tutorials/setup_vscode.html)| [Visual Studio Tutorial](https://eecs280staff.github.io/tutorials/setup_visualstudio.html) | [Xcode Tutorial](https://eecs280staff.github.io/tutorials/setup_xcode.html) |
-
-<div class="primer-spec-callout warning" markdown="1">
-VS Code works great for EECS 281 projects.  Just ask one of the IAs or GSIs who use VS Code if you need help.
-</div>
 
 After you're done, you should have a folder with a main file.  Your files may be different.
 ```console

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -62,11 +62,21 @@ EXECUTABLE = main
 If your project has additional dependencies, update the dependencies section at the bottom of the `Makefile`.
 
 You should be able to compile and run your main file.
+
+If you want to compile a optimized release build use the `make` command:
 ```console
 $ make
 $ ./main
 hello world!
 ```
+
+If you want to compile a debug build use the `make debug` command which includes the debug symbols:
+```console
+$ make debug
+$ ./main
+hello world!
+```
+
 
 ## Arguments and options
 Edit your main program (e.g., `main.cpp`) to parse command line options and print them.  Copy this sample code.

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -125,14 +125,14 @@ int main(int argc, char * argv[]) {
 
 Compile and run.
 ```console
-$ make main
-$ ./main --verbose --output output.txt
+$ make debug
+$ ./main_debug --verbose --output output.txt
 verbose = 1
 output = output.txt
-$ ./main -v -o output.txt
+$ ./main_debug -v -o output.txt
 verbose = 1
 output = output.txt
-$ ./main
+$ ./main_debug
 verbose = 0
 output = 
 ```

--- a/docs/setup_eecs281.md
+++ b/docs/setup_eecs281.md
@@ -24,6 +24,15 @@ p1-stats/
     ...
 ```
 
+<div class="primer-spec-callout warning" markdown="1">
+**VS Code Pitfall:** Use `main_debug` in your [`launch.json` program](setup_vscode.html#edit-launchjson-program).  Your program name might be different.
+
+Don't forget to compile the debug target.
+```console
+$ make debug
+```
+</div>
+
 ## Makefile
 Next, we'll add the [EECS 281 Makefile](https://github.com/eecs281staff/Makefile).
 


### PR DESCRIPTION
Update the EECS 281 tutorial to remind student to compile with `make debug`.

Closes #89