### PR TITLE
Add "touch ~/.zshrc" for zsh customization

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -353,6 +353,7 @@ zsh
 
 Edit your shell customization file
 ```console
+$ touch ~/.zshrc  # Create file if it doesn't exist
 $ open ~/.zshrc
 ```
 {: data-variant="no-line-numbers" }


### PR DESCRIPTION
Potential confusion point found in Piazza: https://piazza.com/class/llcrbmqbuti3lq/post/139
This PR addresses this confusion and also makes the zsh section consistent with the bash section (which already contained a line with touch).