### PR TITLE
Add a warning near the rm command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,7 +159,7 @@ $ brew install tree      # macOS
 
   ```console
   $ rm euchre.cpp
-  $ rm -r stuff2/
+  $ rm -rf stuff2/
   ```
 
   </td>
@@ -168,6 +168,11 @@ $ brew install tree      # macOS
   </td>
   </tr>
 </table>
+
+<div id="pitfall-install-wslview" class="primer-spec-callout warning" markdown="1">
+**Warning:** Files deleted by `rm` are gone forever.  You cannot recover them from the Trash.
+
+</div>
 
 ### `cd`
 `cd` changes directory.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,7 +171,6 @@ $ brew install tree      # macOS
 
 <div id="pitfall-install-wslview" class="primer-spec-callout warning" markdown="1">
 **Warning:** Files deleted by `rm` are gone forever.  You cannot recover them from the Trash.
-
 </div>
 
 ### `cd`


### PR DESCRIPTION
Add a warning to the CLI tutorial that the `rm` command removes files forever.  Also correct an inconsistency to use `rm -rf`.

Thanks to @amirkamil for the suggestion.