### PR TITLE
Move restart section to the end

### DIFF
--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -55,12 +55,6 @@ GNU gdb (GDB)
 
 Next, follow our [Command line interface (CLI)](cli.html) tutorial.
 
-## Restart
-Here's how to delete all Emacs configuration files.  This will not delete your code.  First, quit Emacs.
-```console
-$ rm -rf ~/.emacs ~/.emacs.d/
-```
-
 ## Install
 Choose your platform below.
 
@@ -539,6 +533,12 @@ $ sudo apt-get install emacs-nox
 Many servers have two text editors installed by default: `vi` and `nano`.  Because Nano navigation keyboard shortcuts are similar to Emacs, it's a nice alternative for environments where you need to edit some configuration files, but don't want to install anything.
 ```console
 $ nano main.cpp
+```
+
+## Troubleshootings
+To reset all Emacs configuration, plugins, and settings:
+```console
+$ rm -rf ~/.emacs ~/.emacs.d/
 ```
 
 ## Acknowledgments

--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -535,7 +535,7 @@ Many servers have two text editors installed by default: `vi` and `nano`.  Becau
 $ nano main.cpp
 ```
 
-## Troubleshootings
+## Troubleshooting
 To reset all Emacs configuration, plugins, and settings:
 ```console
 $ rm -rf ~/.emacs ~/.emacs.d/

--- a/docs/setup_git.md
+++ b/docs/setup_git.md
@@ -45,31 +45,6 @@ $ git config --global user.name "YOUR NAME HERE"
 $ git config --global user.email "YOUR EMAIL HERE"
 ```
 
-## Restarting this tutorial
-If you tried using this tutorial in the past and want to start over, here's how to delete the files created by `git` and how to remove your repository from GitHub.
-
-First, remove your GitHub repository.  Browse to your repository's project page from [https://github.com/](https://github.com/).  Select "Settings", scroll to the bottom and select "Delete this repository" under the "Danger Zone" heading.
-
-<img src="images/github001.png" width="768px" />
-
-...
-
-<img src="images/github002.png" width="768px" />
-
-Next, remove the hidden files created by `git`.  Remember, hidden files start with a dot (`.`).
-```console
-$ pwd
-/Users/awdeorio/Developer/eecs280/p2-cv
-$ rm -rf .git/ .gitignore
-$ ls -A
-```
-
-Confirm that this is no longer a git repository.
-```console
-$ git status
-fatal: Not a git repository (or any of the parent directories): .git
-```
-
 ## GitHub Authentication
 There are two ways to connect to GitHub: SSH Keys and GitHub Personal Access Tokens Keys.  An SSH Key is a special file that you can use to connect to remote terminals.  A Personal Access Token works like a separate password used just for GitHub.
 
@@ -767,6 +742,31 @@ On branch main
 Your branch is up to date with 'origin/main'.
 
 nothing to commit, working tree clean
+```
+
+## Troubleshooting
+If you tried using this tutorial in the past and want to start over, here's how to delete the files created by `git` and how to remove your repository from GitHub.
+
+First, remove your GitHub repository.  Browse to your repository's project page from [https://github.com/](https://github.com/).  Select "Settings", scroll to the bottom and select "Delete this repository" under the "Danger Zone" heading.
+
+<img src="images/github001.png" width="768px" />
+
+...
+
+<img src="images/github002.png" width="768px" />
+
+Next, remove the hidden files created by `git`.  Remember, hidden files start with a dot (`.`).
+```console
+$ pwd
+/Users/awdeorio/Developer/eecs280/p2-cv
+$ rm -rf .git/ .gitignore
+$ ls -A
+```
+
+Confirm that this is no longer a git repository.
+```console
+$ git status
+fatal: Not a git repository (or any of the parent directories): .git
 ```
 
 ## Acknowledgments

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -23,20 +23,7 @@ Next, we recommend our [Command line interface (CLI)](cli.html) tutorial.
 
 <div class="primer-spec-callout warning" markdown="1">
 **Pitfall:** Make sure you have installed [CLI tools for Windows](setup_wsl.html#install-cli-tools) before continuing.
-
-
 </div>
-
-## Restart
-To start clean, first quit Visual Studio.  Back up your files, and then delete your project directory.  Your project directory might be different.
-```console
-/Users/awdeorio/src/eecs280
-$ cp -a p1-stats p1-stats.bak  # Backup
-$ rm -rf p1-stats              # Delete
-```
-
-Visual Studio has a *lot* of settings.  You can reset the entire user interface to the default settings by selecting "Tools" -> "Import" and Export Settings" -> "Reset all settings".  This is optional.
-
 
 ## Install
 Install Visual Studio Community edition from [Microsoft's website](https://www.visualstudio.com/vs/community/).
@@ -354,6 +341,17 @@ Click "Step Out".  The `sum()` function completes, and the program pauses again.
 Press "Continue" to run the program to the next breakpoint, or the end, whichever comes first.
 
 <img src="images/visualstudio210.png" width="768px" />
+
+## Troubleshooting
+To reset Visual Studio project settings and starter files, first quit Visual Studio.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
+
+```console
+/Users/awdeorio/src/eecs280
+$ cp -a p1-stats p1-stats.bak  # Backup
+$ rm -rf p1-stats              # Delete
+```
+
+Visual Studio has a *lot* of settings.  You can reset the entire user interface to the default settings by selecting "Tools" -> "Import" and Export Settings" -> "Reset all settings".  This is optional.
 
 ## Acknowledgments
 Original document written by Andrew DeOrio awdeorio@umich.edu.

--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -373,6 +373,11 @@ $ make main.exe
 ```
 </div>
 
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** If you're having trouble running your program, delete your `launch.json` and try the [compile and run](#compile-and-run) section again.
+
+<img src="images/vscode160.png" width="768px" />
+</div>
 
 ### Sanitizers
 We recommend enabling the address sanitizer and undefined behavior sanitizer. These will help you find memory errors like going off the end of an array or vector.
@@ -599,11 +604,6 @@ $ rm -rf p1-stats              # Delete
 ```
 
 Then, return to the [Create a project](#create-a-project) section.
-
-### Compile and run
-If you have trouble with the [compile and run](#compile-and-run) section, a good first step is to delete your `launch.json` and try the [compile and run](#compile-and-run) section again.
-
-<img src="images/vscode160.png" width="768px" />
 
 #### Remove all extensions and configuration
 If you tried recreating your project directory and are still having trouble, try removing all VS Code extensions and configuration.  These instructions are based on the [Microsoft instructions](https://code.visualstudio.com/docs/setup/uninstall#_clean-uninstall).

--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -40,33 +40,6 @@ Next, follow our [Command line interface (CLI)](cli.html) tutorial.
 
 </div>
 
-
-## Restart
-To start clean, first quit VS Code.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
-
-```console
-$ pwd
-/Users/awdeorio/src/eecs280
-$ cp -a p1-stats p1-stats.bak  # Backup
-$ rm -rf p1-stats              # Delete
-```
-
-### Remove all extensions and configuration
-If you tried recreating your project directory and are still having trouble, try removing all VS Code extensions and configuration.  These instructions are based on the [Microsoft instructions](https://code.visualstudio.com/docs/setup/uninstall#_clean-uninstall).
-
-**macOS:**
-```console
-$ rm -rf ~/.vscode
-$ rm -rf ~/Library/Application\ Support/Code
-```
-
-**Windows:**  Replace `awdeorio` with your Windows username.  List the usernames with `ls /mnt/c/Users/`.
-```console
-$ rm -rf ~/.vscode
-$ rm -rf "/mnt/c/Users/awdeorio/.vscode"
-$ rm -rf "/mnt/c/Users/awdeorio/AppData/Roaming/Code"
-```
-
 ## Install
 Choose your platform below. Also make sure to install extensions.
 
@@ -615,10 +588,38 @@ Press "Continue" to run the program to the next breakpoint, or the end, whicheve
 ## Troubleshooting
 This section is for common problems and solutions.
 
+### Restart
+To reset VS Code project settings and starter files, first quit VS Code.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
+
+```console
+$ pwd
+/Users/awdeorio/src/eecs280
+$ cp -a p1-stats p1-stats.bak  # Backup
+$ rm -rf p1-stats              # Delete
+```
+
+Then, return to the [Create a project](#create-a-project) section.
+
 ### Compile and run
 If you have trouble with the [compile and run](#compile-and-run) section, a good first step is to delete your `launch.json` and try the [compile and run](#compile-and-run) section again.
 
 <img src="images/vscode160.png" width="768px" />
+
+#### Remove all extensions and configuration
+If you tried recreating your project directory and are still having trouble, try removing all VS Code extensions and configuration.  These instructions are based on the [Microsoft instructions](https://code.visualstudio.com/docs/setup/uninstall#_clean-uninstall).
+
+**macOS:**
+```console
+$ rm -rf ~/.vscode
+$ rm -rf ~/Library/Application\ Support/Code
+```
+
+**Windows:**  Replace `awdeorio` with your Windows username.  List the usernames with `ls /mnt/c/Users/`.
+```console
+$ rm -rf ~/.vscode
+$ rm -rf "/mnt/c/Users/awdeorio/.vscode"
+$ rm -rf "/mnt/c/Users/awdeorio/AppData/Roaming/Code"
+```
 
 ### Intellisense C++ Standard
 Intellisense is the feature that indicates compiler errors with red squiggly lines and suggests code completions.  If the C++ standard is out-of-date, you'll see squiggles where you shouldn't.

--- a/docs/setup_vscode.md
+++ b/docs/setup_vscode.md
@@ -593,7 +593,7 @@ Press "Continue" to run the program to the next breakpoint, or the end, whicheve
 ## Troubleshooting
 This section is for common problems and solutions.
 
-### Restart
+### Reset
 To reset VS Code project settings and starter files, first quit VS Code.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
 
 ```console

--- a/docs/setup_xcode.md
+++ b/docs/setup_xcode.md
@@ -27,22 +27,6 @@ Next, we recommend our [Command line interface (CLI)](cli.html) tutorial.
 
 </div>
 
-## Restart
-To start clean, first quit Xcode.  Back up your files, and then delete your project directory.  Your project directory might be different.
-```console
-$ pwd
-/Users/awdeorio/src/eecs280
-$ cp -a p1-stats p1-stats.bak  # Backup
-$ rm -rf p1-stats              # Delete
-```
-
-Xcode has a *lot* of settings.  You can reset the entire user interface to the default settings using this command.  This is optional.
-```console
-$ defaults delete com.apple.dt.Xcode
-```
-{: data-variant="no-line-numbers" }
-
-
 ## Install
 Install Xcode using the App Store.  Your version might be different.
 
@@ -383,6 +367,25 @@ Click "Step Out".  The `sum()` function completes, and the program pauses again.
 Press "Continue" to run the program to the next breakpoint, or the end, whichever comes first.
 
 <img src="images/xcode320.png" width="768px" />
+
+
+## Troubleshooting
+To reset Xcode project settings and starter files, first quit Xcode.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
+
+```console
+$ pwd
+/Users/awdeorio/src/eecs280
+$ cp -a p1-stats p1-stats.bak  # Backup
+$ rm -rf p1-stats              # Delete
+```
+
+Xcode has a *lot* of settings.  You can reset the entire user interface to the default settings using this command.  This is optional.
+```console
+$ defaults delete com.apple.dt.Xcode
+```
+{: data-variant="no-line-numbers" }
+
+Then, return to the [Create a project](#create-a-project) section.
 
 
 ## Acknowledgments


### PR DESCRIPTION
Move the "Restart" section to the end of each IDE tutorial.  Same for the Git tutorial.

Closes #146