### PR TITLE
CAEN Linux Requires VPN

### DIFF
--- a/docs/setup_caen.md
+++ b/docs/setup_caen.md
@@ -36,10 +36,10 @@ Test an SSH connection.  Be sure to change `awdeorio` to your own uniqname.
 
 ```console
 $ ssh -T awdeorio@login-course.engin.umich.edu
-The authenticity of host 'login.engin.umich.edu (141.213.74.65)' can't be established.
+The authenticity of host 'login-course.engin.umich.edu (141.213.74.65)' can't be established.
 ECDSA key fingerprint is SHA256:LL0GPTtaVGa6gvv2kVpGq4ZULA1l5pw2wXC4dK3ymIk.
 Are you sure you want to continue connecting (yes/no)? yes
-Warning: Permanently added 'login.engin.umich.edu,141.213.74.65' (ECDSA) to the list of known hosts.
+Warning: Permanently added 'login-course.engin.umich.edu,141.213.74.65' (ECDSA) to the list of known hosts.
 Password: 
 Duo two-factor login for awdeorio
 
@@ -91,7 +91,7 @@ Next, copy files using `rsync`.  Remember to change `awdeorio` to your username.
 ```console
 $ pwd
 /Users/awdeorio/src/eecs280/p1-stats
-$ rsync -rtv --exclude '.git*' ../p1-stats/ awdeorio@login.engin.umich.edu:p1-stats-copy/
+$ rsync -rtv --exclude '.git*' ../p1-stats/ awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 building file list ... done
 created directory p1-stats-copy
 ./
@@ -118,7 +118,7 @@ $ pwd                                  # folder on awdeorio's laptop
 /Users/awdeorio/src/eecs280/p1-stats
 $ hostname                             # name of awdeorio's laptop
 manzana.local
-$ ssh awdeorio@login.engin.umich.edu   # connect to CAEN
+$ ssh awdeorio@login-course.engin.umich.edu   # connect to CAEN
 $ pwd                                  # folder on CAEN computer
 /home/awdeorio
 $ hostname                             # name of a CAEN computer
@@ -188,7 +188,7 @@ Host *
 
 SSH into CAEN Linux.  You'll need to use 2FA.
 ```console
-$ ssh awdeorio@login.engin.umich.edu
+$ ssh awdeorio@login-course.engin.umich.edu
 Password:
 Duo two-factor login for awdeorio
 
@@ -208,7 +208,7 @@ Now, open a second terminal.  We're going to use SSH again, this time via `rsync
 ```console
 $ pwd
 /Users/awdeorio/src/eecs280/p1-stats
-$ rsync -rtv --exclude '.git*' ../p1-stats/ awdeorio@login.engin.umich.edu:p1-stats-copy/
+$ rsync -rtv --exclude '.git*' ../p1-stats/ awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 building file list ... done
 
 sent 273 bytes  received 20 bytes  586.00 bytes/sec
@@ -222,7 +222,7 @@ We can also check out a copy of our committed code on CAEN Linux.
 
 SSH to a CAEN Linux machine and see the copy we made earlier using `rsync`.
 ```console
-$ ssh awdeorio@login.engin.umich.edu
+$ ssh awdeorio@login-course.engin.umich.edu
 $ ls
 p1-stats-copy  # this is from our rsync'ed copy earlier
 ```
@@ -247,14 +247,14 @@ p1-stats p1-stats-copy
 ### Synchronizing deleted files
 Tell `rsync` to synchronize deleted files.  In other words, if it's gone on your laptop, delete it on CAEN.
 ```console
-$ rsync -rtv --delete --exclude '.git*' ../p1-stats/ awdeorio@login.engin.umich.edu:p1-stats-copy/
+$ rsync -rtv --delete --exclude '.git*' ../p1-stats/ awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 ```
 {: data-variant="no-line-numbers" }
 
 ### Don't synchronize Git-ignored files
 Tell `rsync` not to synchronize files ignored by Git.  You can also combine this option with `--delete`.
 ```console
-$ rsync -rtv --exclude '.git*' --filter=':- .gitignore' ../p1-stats/ awdeorio@login.engin.umich.edu:p1-stats-copy/
+$ rsync -rtv --exclude '.git*' --filter=':- .gitignore' ../p1-stats/ awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 ```
 {: data-variant="no-line-numbers" }
 
@@ -269,7 +269,7 @@ sync :
   --exclude '.git*' \
   --filter=':- .gitignore' \
   ../p1-stats/ \
-  awdeorio@login.engin.umich.edu:p1-stats-copy/
+  awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 ```
 
 Now you can type `make sync` as a short cut.
@@ -281,7 +281,7 @@ rsync \
   --exclude '.git*' \
   --filter=':- .gitignore' \
   ../p1-stats/ \
-  awdeorio@login.engin.umich.edu:p1-stats-copy/
+  awdeorio@login-course.engin.umich.edu:p1-stats-copy/
 building file list ... done
 ./
 Makefile

--- a/docs/setup_caen.md
+++ b/docs/setup_caen.md
@@ -8,42 +8,11 @@ CAEN Linux
 ==========
 {: .primer-spec-toc-ignore }
 
-This tutorial will show you how to copy source code from your Laptop to CAEN Linux.  CAEN Linux is a server in the University data center that runs the Linux operating system.  It's useful for making sure that your code works on a computer that is a lot like the autograder.
+This tutorial will show you how to copy source code from your Laptop to CAEN Linux.  CAEN Linux is a server in a University data center that runs the Linux operating system.  It's useful for making sure that your code works on a computer that is a lot like the autograder.
 
 <img src="images/caen005.excalidraw.png" width="768px" class="invert-colors-in-dark-mode" />
 
-Why use CAEN Linux?  One reason is that it has the same compiler used by the autograder, which is useful for making sure you'll get the same results as on your laptop.  For example, on an Apple laptop, `g++` is actually an alias for the Clang compiler supplied by Apple.  Similar things can happen on Windows.
-```console
-$ g++ --version
-Apple clang version 12.0.0 (clang-1200.0.32.29)
-```
-
-After logging in to CAEN Linux, you can use the same compiler used by the autograder.
-```console
-$ g++
-g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
-```
-
 ## Prerequisites
-We're assuming that you already have a folder with starter source code in it, e.g., `p1-stats/`.  You've created new files and added function stubs to make the code base compile, e.g., `stats.cpp` and `main.cpp`.  We expect that your unit tests will fail because many functions are stubs.
-```console
-$ pwd
-/Users/awdeorio/src/eecs280/p1-stats
-$ ls
-Makefile      main_test.out.correct  p1_library.hpp  stats_public_test.cpp
-main.cpp      main_test_data.tsv     stats.cpp       stats_tests.cpp
-main_test.in  p1_library.cpp         stats.hpp
-$ make clean
-rm -rvf *.exe *~ *.out *.dSYM *.stackdump
-$ make test
-g++ -Wall -Werror -pedantic -g --std=c++17 main.cpp stats.cpp p1_library.cpp -o main.exe
-g++ -Wall -Werror -pedantic -g --std=c++17 stats_tests.cpp stats.cpp p1_library.cpp -o stats_tests.exe
-g++ -Wall -Werror -pedantic -g --std=c++17 stats_public_test.cpp stats.cpp p1_library.cpp -o stats_public_test.exe
-./stats_public_test.exe
-Assertion failed: (false), function count, file stats.cpp, line 12.
-countmake: *** [test] Abort trap: 6
-```
-
 You have installed `ssh` and `rsync`.  Your versions might be different.
 ```console
 $ ssh -V
@@ -52,17 +21,21 @@ $ rsync --version
 rsync  version 2.6.9  protocol version 29
 ```
 
-## Test log in
-CAEN is the information technology (IT) services department for the University of Michigan (U-M) College of Engineering.  Everyone who registers for an EECS class (like EECS 280) should receive a CAEN account automatically by the first day class.  If you register after the first day of class, you should get your account within 24 hours of registration.
-
+## Install Duo Mobile
 You'll need a two factor authentication app set up on your mobile device.  Make sure that you have the Duo Mobile app installed and configured according the [ITCS documentation](http://documentation.its.umich.edu/2fa/enroll-smartphone-or-tablet-duo).
 
 <img src="images/caen010.png" width="480px" />
 
-Test if you have access to CAEN Linux computers.  Be sure to change `awdeorio` to your own uniqname.  If this is the first time you're logging in, you'll need to confirm that you want to continue connecting.
+## Install VPN
+To access CAEN Linux from off campus, you'll first need to be connect to the UM VPN Service.  Follow the ITS [instructions](https://its.umich.edu/enterprise/wifi-networks/vpn/getting-started).
+
+## Test log in
+Everyone who registers for an EECS class (like EECS 280) should receive a CAEN account automatically by the first day class.  If you register after the first day of class, you should get your account within 24 hours of registration.
+
+Test an SSH connection.  Be sure to change `awdeorio` to your own uniqname.
 
 ```console
-$ ssh awdeorio@login.engin.umich.edu
+$ ssh -T awdeorio@login-course.engin.umich.edu
 The authenticity of host 'login.engin.umich.edu (141.213.74.65)' can't be established.
 ECDSA key fingerprint is SHA256:LL0GPTtaVGa6gvv2kVpGq4ZULA1l5pw2wXC4dK3ymIk.
 Are you sure you want to continue connecting (yes/no)? yes
@@ -82,17 +55,24 @@ Success. Logging you in...
 -bash-4.2$ 
 ```
 
-<div class="primer-spec-callout info icon-info" markdown="1">
-If you see an error like `Could not chdir to home directory /home/awdeorio: No such file or directory`, a common reason is that you don't have a home directory set up yet.  Request one at the [IFS Storage Request page](https://ifsprovisioning.its.umich.edu/ifs_storage/request). Note that it may take a few hours before your home directory is available across all CAEN systems. If you already have one, you should see "You already have IFS Storage!".
-
-If you're still having trouble accessing your account, see the [CAEN Help Desk](https://caen.engin.umich.edu/contact/).
-</div>
-
 Exit as soon as your test is successful.
 ```console
 $ exit
-Connection to login.engin.umich.edu closed.
+Connection to login-course.engin.umich.edu closed.
 ```
+
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** If you are off campus, make sure you have connected to the [UM VPN](https://its.umich.edu/enterprise/wifi-networks/vpn/getting-started).
+</div>
+
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** If you see an error like this, request a home directory at the [IFS Storage Request page](https://ifsprovisioning.its.umich.edu/ifs_storage/request). It may take a few hours to take effect. If you already have a home directory one, you should see "You already have IFS Storage!".
+```
+Could not chdir to home directory /home/awdeorio: No such file or directory
+```
+
+If you're still having trouble accessing your account, see the [CAEN Help Desk](https://caen.engin.umich.edu/contact/).
+</div>
 
 
 ## Copy files with `rsync`

--- a/docs/setup_caen.md
+++ b/docs/setup_caen.md
@@ -27,7 +27,7 @@ You'll need a two factor authentication app set up on your mobile device.  Make 
 <img src="images/caen010.png" width="480px" />
 
 ## Install VPN
-To access CAEN Linux from off campus, you'll first need to be connect to the UM VPN Service.  Follow the ITS [instructions](https://its.umich.edu/enterprise/wifi-networks/vpn/getting-started).
+To access CAEN Linux from off campus, you'll first need to connect to the UM VPN Service.  Follow the ITS [instructions](https://its.umich.edu/enterprise/wifi-networks/vpn/getting-started).
 
 ## Test log in
 Everyone who registers for an EECS class (like EECS 280) should receive a CAEN account automatically by the first day class.  If you register after the first day of class, you should get your account within 24 hours of registration.
@@ -66,7 +66,7 @@ Connection to login-course.engin.umich.edu closed.
 </div>
 
 <div class="primer-spec-callout warning" markdown="1">
-**Pitfall:** If you see an error like this, request a home directory at the [IFS Storage Request page](https://ifsprovisioning.its.umich.edu/ifs_storage/request). It may take a few hours to take effect. If you already have a home directory one, you should see "You already have IFS Storage!".
+**Pitfall:** If you see an error like this, request a home directory at the [IFS Storage Request page](https://ifsprovisioning.its.umich.edu/ifs_storage/request). It may take a few hours to take effect. If you already have a home directory, you should see "You already have IFS Storage!".
 ```
 Could not chdir to home directory /home/awdeorio: No such file or directory
 ```


### PR DESCRIPTION
CAEN Linux SSH connections from off campus now require the VPN.  I was informed of this via email from CAEN.  It appears that some students are going to them for help.  Please consider this to be somewhat urgent.