### PR TITLE
Reinstall only Ubuntu

### DIFF
--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -92,6 +92,24 @@ $ whoami
 root  # SOMEthiNG IS WRONG
 ```
 
+We recommend you completely reinstall Ubuntu. (Note this will delete all of the data associated with Ubuntu. If you've just installed it, that's fine.)
+
+Open PowerShell and run it as administrator. Run the commands below. You'll be prompted to create a user account.
+
+```console
+PS C:\Users\awdeorio> wsl --unregister Ubuntu
+Unregistering.
+The operation completed successfully.
+
+PS C:\Users\awdeorio> wsl --install -d Ubuntu
+Ubuntu is already installed.
+Launching Ubuntu...
+Installing, this may take a few minutes...
+Please create a default UNIX user account. The username does not need to match your Windows username.
+For more information visit: https://aka.ms/wslusers
+Enter a new UNIX username:
+```
+
 </div>
 
 ## Install CLI tools

--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -92,7 +92,7 @@ $ whoami
 root  # SOMEthiNG IS WRONG
 ```
 
-We recommend you completely reinstall Ubuntu. (Note this will delete all of the data associated with Ubuntu. If you've just installed it, that's fine.)
+We recommend you completely reinstall Ubuntu. (Note this will _delete all of the data associated with Ubuntu_. If you've just installed it, that's fine.)
 
 Open PowerShell and run it as administrator. Run the commands below. You'll be prompted to create a user account.
 
@@ -113,7 +113,7 @@ Enter a new UNIX username:
 </div>
 
 ## Install CLI tools
-Use the `apt` package manager to install a few command line programs.  Linux users will run this same command.
+From an Ubuntu terminal, use the `apt` package manager to install a few command line programs.  Linux users will run this same command.
 ```console
 $ sudo apt update
 $ sudo apt install g++ make rsync wget git ssh gdb python3 tree


### PR DESCRIPTION
This PR fixes #168 by instructing students to only uninstall Ubuntu.

The uninstall and install commands recommended in the Microsoft resources are unlikely to change, so they are directly encoded into the tutorial (rather than a link to an external page - there also isn't an external page I could find that concisely shows the uninstall + install together).

**Verification**
I worked through this process on a spare Windows machine.

1. Start with no WSL installed at all.
2. Install with `wsl --install` from administrator PowerShell.
3. Restart computer as prompted.
4. Open Ubuntu terminal. It prompts to create a user account. Close the terminal without doing that 😈.
5. Open Ubuntu terminal. `whoami` yields `root`.
6. Open PowerShell as administrator. `wsl --unregister Ubuntu`. (Side note, I had an Ubuntu terminal open. It disappeared.)
7. `wsl --install -d Ubuntu` from same PowerShell
8. Output matches the example in this PR, including prompt to create user account. (The PowerShell terminal morphs into bash.)
9. Double check `whoami`. Also check account has sudo privileges. Also check via new Ubuntu terminal. All is good.