### PR TITLE
Add pitfall VSCode WSL / Input redirection

### DIFF
--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -396,6 +396,20 @@ To configure input redirection, edit `launch.json`.  These changes are for the M
 ```
 {: data-title="launch.json" data-highlight="6" }
 
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** Make sure you're using the Microsoft C++ extension.  You should see `cppdbg` in your `launch.json`.  If not, delete your `launch.json` and try the [compile and run](#compile-and-run) section again.
+
+```json
+{
+    "configurations": [
+        {
+            "type": "cppdbg",
+            ...
+```
+{: data-title="launch.json" data-highlight="4" }
+
+</div>
+
 ### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection for EECS 280 project 1.


### PR DESCRIPTION
Add a pitfall to the VSCode / WSL tutorial in the input redirection subsection.  Make sure students are using the right extension.

Closes #171 

## Validation
See new pitfall [here](https://preview.sesh.rs/previews/eecs280staff/tutorials/172/setup_vscode_wsl.html#input-redirection)