### PR TITLE
add CLI setup to Quick Start and adds new column to Setup Tutorial for CLI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,10 +27,33 @@
           Quick Start
         </div>
         <div class="description">
-          <p>Pick an IDE to get started on any C++ project.</p>
+          <p>First, set up your command line for your machine. Then, pick an IDE to get started on any C++ project. In 280, we strongly recommend <a href="setup_vscode.html">VS Code</a>.</p>
         </div>
         <div class="ui hidden divider"></div>
-        <div class="ui three stackable cards">
+        <div class="ui two stackable cards">
+          <a class="ui raised card" target="_blank" href="setup_vscode.html">
+            <div class="content">
+              <div class="header">
+                <i class="icon windows"></i></i> Windows Setup
+              </div>
+              <div class="description">
+                <p>Basic setup on Windows</p>
+              </div>
+            </div>
+          </a>
+          <a class="ui raised card" target="_blank" href="setup_xcode.html">
+            <div class="content">
+              <div class="header">
+                <i class="icon apple"></i> Mac Setup
+              </div>
+              <div class="description">
+                <p>Basic setup on Mac</p>
+              </div>
+            </div>
+          </a>
+        </div><!-- /ui two stackable cards -->
+        <div class="ui hidden divider"></div>
+      <div class="ui three stackable cards">
           <a class="ui raised card" target="_blank" href="setup_vscode.html">
             <div class="content">
               <div class="right aligned floating ui primary label">
@@ -82,8 +105,8 @@
 
         <div class="ui compact internally celled stackable grid" style="font-size: 11pt; margin-top: 0.5em">
 
-          <div class="five wide column">
-            <b>1. Command Line Tools</b>
+          <div class="four wide column">
+            <b>1. Command Line Setup</b>
             <div class="ui list" style="margin-top: 0.5em;">
               <div class="item">
                 <a class="header" target="_blank" href="setup_wsl.html">
@@ -101,6 +124,12 @@
                   Basic setup on macOS
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div class="four wide column">
+            <b>2. Command Line Use</b>
+            <div class="ui list" style="margin-top: 0.5em;">
               <div class="item">
                 <a class="header" target="_blank" href="cli.html">
                   <i class="icon terminal"></i>Command Line
@@ -112,8 +141,8 @@
             </div>
           </div>
 
-          <div class="seven wide column">
-            <b>2. C++ Dev Environment</b> 
+          <div class="five wide column">
+            <b>3. C++ Dev Environment</b> 
             <div class="ui list" style="margin-top: 0.5em;">
               <div class="item">
                 <a class="header" target="_blank" href="setup_vscode.html">
@@ -142,8 +171,8 @@
             </div>
           </div>
 
-          <div class="four wide column">
-            <b>3. C++ Compilation</b>
+          <div class="three wide column">
+            <b>4. C++ Compilation</b>
             <div class="ui list" style="margin-top: 0.5em;">
               <div class="item">
                 <a class="header" target="_blank" href="make.html">

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,10 +44,10 @@
           <a class="ui raised card" target="_blank" href="setup_xcode.html">
             <div class="content">
               <div class="header">
-                <i class="icon apple"></i> Mac Setup
+                <i class="icon apple"></i> macOS Setup
               </div>
               <div class="description">
-                <p>Basic setup on Mac</p>
+                <p>Basic setup on macOS</p>
               </div>
             </div>
           </a>


### PR DESCRIPTION
Closes #167 and also adds CLI setup to Quick Start, so it's clearer to students to get command line tools/install WSL, etc. Only changing the main tutorial page, not any of the tutorial material. Resulting tutorial page looks like the below: 

![Screenshot 2024-02-17 at 5 24 17 PM](https://github.com/eecs280staff/tutorials/assets/8115839/16a8ee56-2c3d-4194-966a-683312a616c7)
