### PR TITLE
Suggest `make clean` in Sanitizers tutorial

### DIFF
--- a/docs/setup_asan.md
+++ b/docs/setup_asan.md
@@ -20,6 +20,7 @@ To enable the address sanitizer, add these compiler flags to add to your `Makefi
 **Pitfall:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
 ```console
 $ make clean
+```
 </div>
 
 **WSL or Linux:** Add compiler flags `-fsanitize=address`, `-fsanitize=undefined`, and `-D_GLIBCXX_DEBUG`.  For example:

--- a/docs/setup_asan.md
+++ b/docs/setup_asan.md
@@ -17,7 +17,9 @@ If you're interested, here is more information about the [Address Sanitizer](htt
 To enable the address sanitizer, add these compiler flags to add to your `Makefile`.
 
 <div class="primer-spec-callout warning" markdown="1">
-**Note:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
+**Pitfall:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
+```console
+$ make clean
 </div>
 
 **WSL or Linux:** Add compiler flags `-fsanitize=address`, `-fsanitize=undefined`, and `-D_GLIBCXX_DEBUG`.  For example:

--- a/docs/setup_asan.md
+++ b/docs/setup_asan.md
@@ -16,6 +16,10 @@ If you're interested, here is more information about the [Address Sanitizer](htt
 ## Quick Start
 To enable the address sanitizer, add these compiler flags to add to your `Makefile`.
 
+<div class="primer-spec-callout warning" markdown="1">
+**Note:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
+</div>
+
 **WSL or Linux:** Add compiler flags `-fsanitize=address`, `-fsanitize=undefined`, and `-D_GLIBCXX_DEBUG`.  For example:
 ```make
 CXXFLAGS = --std=c++17 -Wall -Werror -pedantic -g -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG

--- a/docs/setup_asan.md
+++ b/docs/setup_asan.md
@@ -16,13 +16,6 @@ If you're interested, here is more information about the [Address Sanitizer](htt
 ## Quick Start
 To enable the address sanitizer, add these compiler flags to add to your `Makefile`.
 
-<div class="primer-spec-callout warning" markdown="1">
-**Pitfall:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
-```console
-$ make clean
-```
-</div>
-
 **WSL or Linux:** Add compiler flags `-fsanitize=address`, `-fsanitize=undefined`, and `-D_GLIBCXX_DEBUG`.  For example:
 ```make
 CXXFLAGS = --std=c++17 -Wall -Werror -pedantic -g -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG
@@ -39,6 +32,12 @@ CXXFLAGS = --std=c++17 -Wall -Werror -pedantic -g -fsanitize=address -fsanitize=
 
 **Xcode:** Enable the address sanitizer and undefined behavior sanitizer with this ([tutorial](setup_xcode.html#sanitizers)).
 
+<div class="primer-spec-callout warning" markdown="1">
+**Pitfall:** If you enable sanitizers in your `Makefile` and change nothing else in your code, you will need to do a `make clean` to recompile with the sanitizers on.
+```console
+$ make clean
+```
+</div>
 
 ## Example without Address Sanitizer
 Let's do an example without an address sanitizer.  We'll make a mistake on purpose in `asan.cpp`, going off the end of a `vector`.


### PR DESCRIPTION
Adds a warning to run `make clean` after enabling sanitizers in Makefile to the Sanitizers tutorial