### PR TITLE
Remove Redundant Steps in WSL Reinstall

### DIFF
--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -86,7 +86,8 @@ awdeorio  # this should NOT say root
 ```
 
 <div class="primer-spec-callout warning" markdown="1">
-**Pitfall:** If you are signed in as [root](#root-user), something has gone wrong. We recommend that you [uninstall](https://www.makeuseof.com/uninstall-wsl-windows/) and [reinstall](#install-wsl) WSL to try again.
+**Pitfall:** If you are signed in as [root](#root-user), something has gone wrong.
+  
 ```console
 $ whoami
 root  # SOMEthiNG IS WRONG


### PR DESCRIPTION
The pitfall that instructs students to reinstall Ubuntu if they accidentally skip creating a root account has some redundant steps. I had intended to remove these when replacing with the easier reinstall method in #169 but must have missed doing it.