### PR TITLE
Update to OCLint 22.02

### DIFF
--- a/docs/setup_style.md
+++ b/docs/setup_style.md
@@ -34,10 +34,8 @@ Success. Logging you in...
 
 You have some source code you want to check.  Our example contains a long line.
 ```c++
-int main() {
 #include <iostream>
 using namespace std;
-
 
 int main() {
   // primer-spec-highlight-start

--- a/docs/setup_style.md
+++ b/docs/setup_style.md
@@ -63,7 +63,6 @@ $ hostname
 caen-vnc-vm16.engin.umich.edu
 $ module load oclint
 $ oclint \
-    -no-analytics \
     -rule=LongLine \
     -rule=HighNcssMethod \
     -rule=DeepNestedBlock \
@@ -82,9 +81,9 @@ OCLint Report
 
 Summary: TotalFiles=1 FilesWithViolations=1 P1=0 P2=0 P3=1
 
-/home/awdeorio/test.cpp:6:1: long line [size|P3] Line with 104 characters exceeds limit of 90
+/home/jjuett/temp/test.cpp:6:1: long line [size|P3] Line with 104 characters exceeds limit of 90
 
-[OCLint (http://oclint.org) v0.13]
+[OCLint (https://oclint.org) v22.02]
 
 oclint: error: violations exceed threshold
 P1=0[0] P2=0[0] P3=1[0]

--- a/docs/setup_style.md
+++ b/docs/setup_style.md
@@ -81,7 +81,7 @@ OCLint Report
 
 Summary: TotalFiles=1 FilesWithViolations=1 P1=0 P2=0 P3=1
 
-/home/jjuett/temp/test.cpp:6:1: long line [size|P3] Line with 104 characters exceeds limit of 90
+/home/awdeorio/test.cpp:6:1: long line [size|P3] Line with 104 characters exceeds limit of 90
 
 [OCLint (https://oclint.org) v22.02]
 


### PR DESCRIPTION
This PR updates the style checking tutorial for OCLint 22.02.

The changes are minor, since the main changes are updates to the `make style` target provided with individual projects. The `-no-analytics` option is no longer used, and the output includes the new version number.

Also fixes an existing typo in the example.