### PR TITLE
Update for Revised P1

### DIFF
--- a/docs/setup_emacs.md
+++ b/docs/setup_emacs.md
@@ -325,15 +325,15 @@ You should see your new files in your project directory.
 $ tree
 .
 ├── Makefile
+├── cats.csv
+├── cats.out.correct
 ├── main.cpp
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
 ├── p1_library.cpp
 ├── p1_library.hpp
 ├── stats.hpp
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
+├── stats_public_tests.cpp
+├── stats_tests.cpp.starter
+└── two_sample.cpp.starter
 ```
 
 #### Rename files

--- a/docs/setup_gdb.md
+++ b/docs/setup_gdb.md
@@ -92,17 +92,6 @@ We recommend enabling the address sanitizer and undefined behavior sanitizer. Th
 
 First, edit your `Makefile` and add the `CXXFLAGS` recommended by the [ASAN Quick Start](setup_asan.html#quick-start).
 
-### Input redirection
-If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
-
-Run with input redirection.  Make sure to add the name of your input file (`main_test.in` in this example).
-```
-$ gdb main.exe
-...
-(gdb) r < main_test.in
-...
-```
-
 ### Arguments and options
 Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
 ```console
@@ -120,6 +109,17 @@ $ gdb main.exe
 (gdb) r train_small.csv test_small.csv --debug
 ```
 {: data-highlight="2" }
+
+### Input redirection
+If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
+
+Run with input redirection.  Make sure to add the name of your input file (`main_test.in` in this example).
+```
+$ gdb main.exe
+...
+(gdb) r < main_test.in
+...
+```
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.

--- a/docs/setup_gdb.md
+++ b/docs/setup_gdb.md
@@ -93,7 +93,7 @@ We recommend enabling the address sanitizer and undefined behavior sanitizer. Th
 First, edit your `Makefile` and add the `CXXFLAGS` recommended by the [ASAN Quick Start](setup_asan.html#quick-start).
 
 ### Arguments and options
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_lldb.md
+++ b/docs/setup_lldb.md
@@ -91,18 +91,6 @@ We recommend enabling the address sanitizer and undefined behavior sanitizer. Th
 
 First, edit your `Makefile` and add the `CXXFLAGS` recommended by the [ASAN Quick Start](setup_asan.html#quick-start).
 
-### Input redirection
-If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
-
-Run with input redirection.  Make sure to add the name of your input file (`main_test.in` in this example).
-```
-$ lldb main.exe
-...
-(lldb) settings set target.input-path main_test.in
-(lldb) r
-...
-```
-
 ### Arguments and options
 Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
 ```console
@@ -120,6 +108,18 @@ $ lldb main.exe
 (lldb) r train_small.csv test_small.csv --debug
 ```
 {: data-highlight="2" }
+
+### Input redirection
+If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
+
+Run with input redirection.  Make sure to add the name of your input file (`main_test.in` in this example).
+```
+$ lldb main.exe
+...
+(lldb) settings set target.input-path main_test.in
+(lldb) r
+...
+```
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.

--- a/docs/setup_lldb.md
+++ b/docs/setup_lldb.md
@@ -92,7 +92,7 @@ We recommend enabling the address sanitizer and undefined behavior sanitizer. Th
 First, edit your `Makefile` and add the `CXXFLAGS` recommended by the [ASAN Quick Start](setup_asan.html#quick-start).
 
 ### Arguments and options
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -214,7 +214,7 @@ Visual Studio provides an address sanitizer with bounds checking automatically w
 Skip this subsection your first time through the tutorial.  You can come back to it.
 </div>
 
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -209,9 +209,32 @@ Visual Studio provides an address sanitizer with bounds checking automatically w
 
 </div>
 
-### Input redirection
+### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection your first time through the tutorial.  You can come back to it.
+</div>
+
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+```console
+$ ./main.exe train_small.csv test_small.csv --debug
+```
+{: data-variant="no-line-numbers" data-highlight="1" }
+
+- `main.exe` is the name of the program
+- `train_small.csv` and `test_small.csv` are arguments
+- `--debug` is an option
+
+Right-click the project in the Solution Explorer (`p1-stats` in this example).  Select "Properties".
+
+<img src="images/visualstudio148.png" width="320px" />
+
+Edit "Command Arguments" and click "OK".
+
+<img src="images/visualstudio149.png" width="768px" />
+
+### Input redirection
+<div class="primer-spec-callout info" markdown="1">
+Skip this subsection for EECS 280 project 1.
 </div>
 
 If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
@@ -233,30 +256,6 @@ Edit "Command Arguments" and click "OK".
 
 Set a breakpoint on the last line of `main` to keep the output window open.
 </div>
-
-
-### Arguments and options
-<div class="primer-spec-callout info" markdown="1">
-Skip this subsection for EECS 280 project 1.
-</div>
-
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
-```console
-$ ./main.exe train_small.csv test_small.csv --debug
-```
-{: data-variant="no-line-numbers" data-highlight="1" }
-
-- `main.exe` is the name of the program
-- `train_small.csv` and `test_small.csv` are arguments
-- `--debug` is an option
-
-Right-click the project in the Solution Explorer (`p1-stats` in this example).  Select "Properties".
-
-<img src="images/visualstudio148.png" width="320px" />
-
-Edit "Command Arguments" and click "OK".
-
-<img src="images/visualstudio149.png" width="768px" />
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -155,7 +155,7 @@ Right-click "Source Files", then select "Add" > "Existing Item".
 
 <img src="images/visualstudio105.png" width="768px" />
  
-Navigate to your project directory.  Select your files by holding <kbd>Control</kbd> and clicking each one.  Do *not* select any `.sln` or `.vcxproj` files.  Click "Add".
+Navigate to your project directory.  Select your files by holding <kbd>Control</kbd> and clicking each one.  Your specific files may not match the image below. Do *not* select any `.sln` or `.vcxproj` files.  Click "Add". 
 
 <img src="images/visualstudio106.png" width="512px" />
 

--- a/docs/setup_visualstudio.md
+++ b/docs/setup_visualstudio.md
@@ -136,10 +136,9 @@ You should see your new files in the `src` subdirectory.
 $ tree
 .
 ├── Makefile
+├── cats.csv
+├── cats.out.correct
 ├── main.cpp
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
 ├── p1-stats.sln
 ├── p1-stats.vcxproj
 ├── p1-stats.vcxproj.filters
@@ -147,8 +146,9 @@ $ tree
 ├── p1_library.cpp
 ├── p1_library.hpp
 ├── stats.hpp
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
+├── stats_public_tests.cpp
+├── stats_tests.cpp.starter
+└── two_sample.cpp.starter
 ```
 
 Right-click "Source Files", then select "Add" > "Existing Item".

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -164,15 +164,15 @@ You should see your new files in your project directory.
 $ tree
 .
 ├── Makefile
+├── cats.csv
+├── cats.out.correct
 ├── main.cpp
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
 ├── p1_library.cpp
 ├── p1_library.hpp
 ├── stats.hpp
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
+├── stats_public_tests.cpp
+├── stats_tests.cpp.starter
+└── two_sample.cpp.starter
 ```
 
 You should see your new files appear in VS Code.

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -303,9 +303,39 @@ Open Settings on VSCode (Code > Settings > Settings). Search for "lldb: show dis
 
 <img src="images/vscode_macos_037.png" width="768px" />
 
-### Input redirection
+### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection your first time through the tutorial.  You can come back to it.
+</div>
+
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+```console
+$ ./main.exe train_small.csv test_small.csv --debug
+```
+{: data-variant="no-line-numbers" data-highlight="1" }
+
+- `main.exe` is the name of the program
+- `train_small.csv` and `test_small.csv` are arguments
+- `--debug` is an option
+
+To run a program with options or arguments in VS Code, edit `launch.json`.  Each option or argument should goes in a separate comma-separated string.
+```json
+{
+    "configurations": [
+        {
+            ...
+            "program": "${workspaceFolder}/main.exe",
+            "args": ["train_small.csv", "test_small.csv", "--debug"],
+            ...
+        }
+    ]
+}
+```
+{: data-title="launch.json" data-highlight="6" }
+
+### Input redirection
+<div class="primer-spec-callout info" markdown="1">
+Skip this subsection for EECS 280 project 1.
 </div>
 
 If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
@@ -338,36 +368,6 @@ To configure input redirection, edit `launch.json` ([docs](https://github.com/va
 {: data-title="launch.json" data-highlight="4" }
 
 </div>
-
-### Arguments and options
-<div class="primer-spec-callout info" markdown="1">
-Skip this subsection for EECS 280 project 1.
-</div>
-
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
-```console
-$ ./main.exe train_small.csv test_small.csv --debug
-```
-{: data-variant="no-line-numbers" data-highlight="1" }
-
-- `main.exe` is the name of the program
-- `train_small.csv` and `test_small.csv` are arguments
-- `--debug` is an option
-
-To run a program with options or arguments in VS Code, edit `launch.json`.  Each option or argument should goes in a separate comma-separated string.
-```json
-{
-    "configurations": [
-        {
-            ...
-            "program": "${workspaceFolder}/main.exe",
-            "args": ["train_small.csv", "test_small.csv", "--debug"],
-            ...
-        }
-    ]
-}
-```
-{: data-title="launch.json" data-highlight="6" }
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -175,14 +175,14 @@ $ tree
 └── two_sample.cpp.starter
 ```
 
-You should see your new files appear in VS Code.
+You should see your new files appear in VS Code. Your specific files may not match the image below.
 
 <img src="images/vscode_macos_026.png" width="768px" />
 
 #### Rename files
-If you need to rename any files, you can do this from VS Code or from the command line.  In EECS 280, you'll need to rename any files that end in `.starter`.
+If you need to rename any files, you can do this in VS Code by right clicking a file and selecting "rename".
 
-Right click a file and select "rename".  Change the file name.  In EECS 280, you'll do this to any file that ends in `.starter`.
+In EECS 280, you'll do this to any file that ends in `.starter`.
 
 | <img src="images/vscode_macos_027.png" height="512px" /> | <img src="images/vscode_macos_028.png" height="512px" /> |
 

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -308,7 +308,7 @@ Open Settings on VSCode (Code > Settings > Settings). Search for "lldb: show dis
 Skip this subsection your first time through the tutorial.  You can come back to it.
 </div>
 
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -378,7 +378,7 @@ Edit the `"environment"` property in your `launch.json`.  If there's already an 
 Skip this subsection your first time through the tutorial.  You can come back to it.
 </div>
 
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -373,9 +373,39 @@ Edit the `"environment"` property in your `launch.json`.  If there's already an 
 ```
 {: data-highlight="3-4" }
 
-### Input redirection
+### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection your first time through the tutorial.  You can come back to it.
+</div>
+
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+```console
+$ ./main.exe train_small.csv test_small.csv --debug
+```
+{: data-variant="no-line-numbers" data-highlight="1" }
+
+- `main.exe` is the name of the program
+- `train_small.csv` and `test_small.csv` are arguments
+- `--debug` is an option
+
+To run a program with options or arguments in VS Code, edit `launch.json`.  Each option or argument should goes in a separate comma-separated string.
+```json
+{
+    "configurations": [
+        {
+            ...
+            "program": "${workspaceFolder}/main.exe",
+            "args": ["train_small.csv", "test_small.csv", "--debug"],
+            ...
+        }
+    ]
+}
+```
+{: data-title="launch.json" data-highlight="6" }
+
+### Input redirection
+<div class="primer-spec-callout info" markdown="1">
+Skip this subsection for EECS 280 project 1.
 </div>
 
 If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
@@ -408,36 +438,6 @@ To configure input redirection, edit `launch.json`.  These changes are for the M
 {: data-title="launch.json" data-highlight="4" }
 
 </div>
-
-### Arguments and options
-<div class="primer-spec-callout info" markdown="1">
-Skip this subsection for EECS 280 project 1.
-</div>
-
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
-```console
-$ ./main.exe train_small.csv test_small.csv --debug
-```
-{: data-variant="no-line-numbers" data-highlight="1" }
-
-- `main.exe` is the name of the program
-- `train_small.csv` and `test_small.csv` are arguments
-- `--debug` is an option
-
-To run a program with options or arguments in VS Code, edit `launch.json`.  Each option or argument should goes in a separate comma-separated string.
-```json
-{
-    "configurations": [
-        {
-            ...
-            "program": "${workspaceFolder}/main.exe",
-            "args": ["train_small.csv", "test_small.csv", "--debug"],
-            ...
-        }
-    ]
-}
-```
-{: data-title="launch.json" data-highlight="6" }
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -207,14 +207,14 @@ $ tree
 └── two_sample.cpp.starter
 ```
 
-You should see your new files appear in VS Code.
+You should see your new files appear in VS Code. Your specific files may not match the image below.
 
 <img src="images/vscode_wsl_026.png" width="768px" />
 
 #### Rename files
-If you need to rename any files, you can do this from VS Code or from the command line.  In EECS 280, you'll need to rename any files that end in `.starter`.
+If you need to rename any files, you can do this in VS Code by right clicking a file and selecting "rename".
 
-Right click a file and select "rename".  Change the file name.  In EECS 280, you'll do this to any file that ends in `.starter`.
+In EECS 280, you'll do this to any file that ends in `.starter`.
 
 | <img src="images/vscode_wsl_027.png" height="512px" /> | <img src="images/vscode_wsl_028.png" height="512px" /> |
 

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -196,15 +196,15 @@ You should see your new files in your project directory.
 $ tree
 .
 ├── Makefile
+├── cats.csv
+├── cats.out.correct
 ├── main.cpp
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
 ├── p1_library.cpp
 ├── p1_library.hpp
 ├── stats.hpp
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
+├── stats_public_tests.cpp
+├── stats_tests.cpp.starter
+└── two_sample.cpp.starter
 ```
 
 You should see your new files appear in VS Code.

--- a/docs/setup_xcode.md
+++ b/docs/setup_xcode.md
@@ -142,17 +142,17 @@ You should see your new files in your project directory.
 $ tree
 .
 ├── Makefile
+├── cats.csv
+├── cats.out.correct
 ├── main.cpp
-├── main_test.in
-├── main_test.out.correct
-├── main_test_data.tsv
 ├── p1-stats.xcodeproj
 │   ├── ...
 ├── p1_library.cpp
 ├── p1_library.hpp
 ├── stats.hpp
-├── stats_public_test.cpp
-└── stats_tests.cpp.starter
+├── stats_public_tests.cpp
+├── stats_tests.cpp.starter
+└── two_sample.cpp.starter
 ```
 
 Start Xcode and open your project.

--- a/docs/setup_xcode.md
+++ b/docs/setup_xcode.md
@@ -234,7 +234,7 @@ Select your scheme, then "Edit Scheme".  You can also use menu: Product > Scheme
 Skip this subsection your first time through the tutorial.  You can come back to it.
 </div>
 
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 4:
 ```console
 $ ./main.exe train_small.csv test_small.csv --debug
 ```

--- a/docs/setup_xcode.md
+++ b/docs/setup_xcode.md
@@ -161,7 +161,7 @@ Right-click `p1-stats` in the sidebar.  Select "Add Files".
 
 <img src="images/xcode080.png" width="256px" />
 
-Select all the starter files (<kbd>Command</kbd> + <kbd>a</kbd>).  Do *not* select "Copy items if needed".  Click "Add".
+Select all the starter files (<kbd>Command</kbd> + <kbd>a</kbd>). Your specific files may not match the image below. Do *not* select "Copy items if needed". Do *not* select any targets. Click "Add".
 
 <img src="images/xcode100.png" width="384px" />
 

--- a/docs/setup_xcode.md
+++ b/docs/setup_xcode.md
@@ -229,9 +229,32 @@ Select your scheme, then "Edit Scheme".  You can also use menu: Product > Scheme
 
 <img src="images/xcode170.png" width="768px" />
 
-### Input redirection
+### Arguments and options
 <div class="primer-spec-callout info" markdown="1">
 Skip this subsection your first time through the tutorial.  You can come back to it.
+</div>
+
+Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
+```console
+$ ./main.exe train_small.csv test_small.csv --debug
+```
+{: data-variant="no-line-numbers" data-highlight="1" }
+
+- `main.exe` is the name of the program
+- `train_small.csv` and `test_small.csv` are arguments
+- `--debug` is an option
+
+Select your scheme, then "Edit Scheme".  You can also use menu: Product > Scheme > Edit Scheme.
+
+| <img src="images/xcode149.png" width="384px" /> | <img src="images/xcode150.png" width="384px" /> |
+
+Add each option or argument separately.
+
+<img src="images/xcode259.png" width="576px" />
+
+### Input redirection
+<div class="primer-spec-callout info" markdown="1">
+Skip this subsection for EECS 280 project 1.
 </div>
 
 If you're unfamiliar with input redirection, first read the CLI tutorial section on [input redirection](cli.html#input-redirection-).
@@ -261,29 +284,6 @@ int main() {
 ```
 
 To stop input redirection, comment or delete these lines.
-
-### Arguments and options
-<div class="primer-spec-callout info" markdown="1">
-Skip this subsection for EECS 280 project 1.
-</div>
-
-Arguments and options are inputs to a program typed at the command line.  Here's an example from EECS 280 Project 5:
-```console
-$ ./main.exe train_small.csv test_small.csv --debug
-```
-{: data-variant="no-line-numbers" data-highlight="1" }
-
-- `main.exe` is the name of the program
-- `train_small.csv` and `test_small.csv` are arguments
-- `--debug` is an option
-
-Select your scheme, then "Edit Scheme".  You can also use menu: Product > Scheme > Edit Scheme.
-
-| <img src="images/xcode149.png" width="384px" /> | <img src="images/xcode150.png" width="384px" /> |
-
-Add each option or argument separately.
-
-<img src="images/xcode259.png" width="576px" />
 
 ## Debug
 In this section, we'll set a breakpoint, which pauses the debugger.  Then, we'll cover some of the options to continue execution.


### PR DESCRIPTION
We're releasing a revised P1 this term. This PR makes a few updates to the tutorial to match.

**P1 Starter Files**
The tutorials show output from `tree` and include several screenshots of various IDEs that happen to show some files. I updated the `tree` output since that was easy and it's nice to have that match. Instead of updating many images (which aren't necessarily focused on the exact starter files), I added a note that "your specific starter files might not match the image" where appropriate.

**Command Line Args instead of Input Redirection**
P1 now uses command line arguments instead of input redirection. So, I moved the command line arguments section before the input redirection section. I also switched the messages at the top of each, so that students are told to skip input redirection for P1.