### PR TITLE
Add Troubleshooting Item for Infinite Help Message

### DIFF
--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -227,6 +227,9 @@ Once virtualization is enabled, ensure the "Virtual Machine Platform" feature is
 
 Attempt to install WSL again, following the instructions at the top of this guide.
 
+### Enable Windows Subsystem for Linux
+If you're running commands like `wsl -l -v` or `wsl --install Ubuntu-24.04`, but it just prints out a generic help message, you may need to enable the Windows Subsystem for Linux feature. Search for "Turn Windows features on or off" in the start menu. Scroll down and ensure that "Windows Subsystem for Linux" is checked. If it is not, check the box and click "OK". You may be asked to restart your computer.
+
 ### Microsoft Troubleshooting
 
 Microsoft maintains an extensive [troubleshooting page](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues) for WSL installation. If you're getting a specific error code/message, you may be able to match it with a resolution here.


### PR DESCRIPTION
I ran into a student who got the usage message no matter what when they tried a `wsl` command from powershell. Even `wsl --version`. Some searching online suggested the fix added in this PR, which is to manually enable WSL in windows features, and that ended up solving the problem. I didn't think you had to do this anymore, but maybe this student had done something to specifically disable it.