### PR TITLE
Use -d in wsl install command

### DIFF
--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -49,7 +49,7 @@ Usage: wsl.exe [Argument]
 
 Install WSL.  We recommend the most recent Ubuntu LTS version from the [Microsoft App Store](https://apps.microsoft.com/search?query=ubuntu+lts), currently Ubuntu 24.04.
 ```console
-C:\WINDOWS\system32> wsl --install Ubuntu-24.04
+C:\WINDOWS\system32> wsl --install -d Ubuntu-24.04
 ```
 
 <div class="primer-spec-callout warning" markdown="1">
@@ -228,7 +228,7 @@ Once virtualization is enabled, ensure the "Virtual Machine Platform" feature is
 Attempt to install WSL again, following the instructions at the top of this guide.
 
 ### Enable Windows Subsystem for Linux
-If you're running commands like `wsl -l -v` or `wsl --install Ubuntu-24.04`, but it just prints out a generic help message, you may need to enable the Windows Subsystem for Linux feature. Search for "Turn Windows features on or off" in the start menu. Scroll down and ensure that "Windows Subsystem for Linux" is checked. If it is not, check the box and click "OK". You may be asked to restart your computer.
+If you're running commands like `wsl -l -v` or `wsl --install -d Ubuntu-24.04`, but it just prints out a generic help message, you may need to enable the Windows Subsystem for Linux feature. Search for "Turn Windows features on or off" in the start menu. Scroll down and ensure that "Windows Subsystem for Linux" is checked. If it is not, check the box and click "OK". You may be asked to restart your computer.
 
 ### Microsoft Troubleshooting
 


### PR DESCRIPTION
In #186, I made a commit to simplify the command from `wsl --install -d Ubuntu-24.04` to `wsl --install Ubuntu-24.04`.

I shouldn't have done that :). It turns out that on Windows 10 or outdated versions of the `wsl` command itself, the `-d` is required. See the note at the bottom of the `wsl --install` section here: https://learn.microsoft.com/en-us/windows/wsl/basic-commands#install

This PR adds back the `-d`.