### PR TITLE
Add Instructions for Reinstalling Compiler on Mac

### DIFF
--- a/docs/setup_macos.md
+++ b/docs/setup_macos.md
@@ -103,10 +103,17 @@ Opens a file or directory with the default application, like a double click.  Se
 This section is for common problems and solutions.
 
 ### Reinstall Compiler
-You may notice that your compiler stops working or that the C++ standard library is unavailable (i.e. `#include` stops working) after installing other software development tools or after a macOS update. Reinstall your command line tools and compiler to fix this issue:
+You may notice that your compiler stops working or that the C++ standard library is unavailable (i.e. `#include` stops working) after installing other software development tools or after a macOS update. Reinstall your command line tools and compiler to fix this issue.
+
+First, remove the previous command line tools. Be careful to enter this command correctly. You will be prompted to enter your password.
 
 ```console
 $ sudo rm -rf /Library/Developer/CommandLineTools
+```
+
+Next, reinstall the command line tools. A separate window will pop up asking you to confirm. It may take several minutes to install.
+
+```console
 $ xcode-select --install
 ```
 

--- a/docs/setup_macos.md
+++ b/docs/setup_macos.md
@@ -99,6 +99,19 @@ Now would be a great time to take a look at our [CLI Tutorial](cli.html).
 Opens a file or directory with the default application, like a double click.  See the [`open` command](cli.html#open--wslview) in the CLI tutorial.
 
 
+## Troubleshooting
+This section is for common problems and solutions.
+
+### Reinstall Compiler
+You may notice that your compiler stops working or that the C++ standard library is unavailable (i.e. `#include` stops working) after installing other software development tools or after a macOS update. Reinstall your command line tools and compiler to fix this issue:
+
+```console
+$ sudo rm -rf /Library/Developer/CommandLineTools
+$ xcode-select --install
+```
+
+If you are working in an IDE like VS Code, you'll need to close and restart it as well.
+
 ## Acknowledgments
 Original document written by Andrew DeOrio awdeorio@umich.edu.
 

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -491,7 +491,10 @@ Press "Continue" to run the program to the next breakpoint, or the end, whicheve
 ## Troubleshooting
 This section is for common problems and solutions.
 
-### Reset
+### Reinstall Compiler
+If your compiler or `#include`s aren't working, try [reinstalling your compiler](setup_macos.html#reinstall-compiler) to fix this issue.
+
+### Reset VS Code Project Settings
 To reset VS Code project settings and starter files, first quit VS Code.  Make a backup copy of your files, and then delete your project directory.  Your project directory might be different.
 
 ```console


### PR DESCRIPTION
Many students on Mac have been running into issues with their compiler. Reinstalling the XCode command-line tools seems to fix the issue.

In some cases, the standard library is no longer available and `#includes` stop working.

In other cases, students are getting a message like `xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools)`.

This PR adds a troubleshooting section with instructions for removing and reinstalling.