### PR TITLE
fix (setup_asan.md): license misstates rights

### DIFF
--- a/docs/setup_asan.md
+++ b/docs/setup_asan.md
@@ -127,4 +127,4 @@ endif
 ## Acknowledgments
 Original document written by Andrew DeOrio awdeorio@umich.edu.
 
-This document is licensed under a [Creative Commons Attribution-NonCommercial 4.0 License](https://creativecommons.org/licenses/by-nc/4.0/). You’re free to copy and share this document, but not to sell it. You may not share source code provided with this document.
+This document is licensed under a [Creative Commons Attribution-NonCommercial 4.0 License](https://creativecommons.org/licenses/by-nc/4.0/). You’re free to copy and share this document, but not to sell it.


### PR DESCRIPTION
The CC BY-NC 4.0 allows for the sharing and adaptation of all material under this license, saying that users may not share or adapt the source code in this document is not accurate. The license explicitly forbids imposing other requirements.

See attached deed:
https://creativecommons.org/licenses/by-nc/4.0/deed.en