### PR TITLE
Remove WSL terminology from macOS tutorials

### DIFF
--- a/docs/setup_macos.md
+++ b/docs/setup_macos.md
@@ -61,7 +61,7 @@ $ brew install wget git tree
 ```
 
 ## Home Directory
-Run `cd ~`. This will take you to your Ubuntu home directory. Running `pwd` afterward confirms the location. (Your username will be different.)
+Run `cd ~`. This will take you to your home directory. Running `pwd` afterward confirms the location. (Your username will be different.)
 
 ```console
 $ cd ~

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -88,7 +88,7 @@ $ mkdir -p ~/eecs280/p1-stats
 $ cd ~/eecs280/p1-stats
 ```
 
-This `mkdir -p` command creates a new `p1-stats` folder within an `eecs280` folder (creating that too, if it doesn't exist), within your Ubuntu home directory (`~`). The `cd` command changes your working directory to the new `p1-stats` directory.
+This `mkdir -p` command creates a new `p1-stats` folder within an `eecs280` folder (creating that too, if it doesn't exist), within your home directory (`~`). The `cd` command changes your working directory to the new `p1-stats` directory.
 
 <div class="primer-spec-callout warning" markdown="1">
 **Pitfall:** Avoid paths that contain spaces.  Spaces causes problems with some command line tools.


### PR DESCRIPTION
macOS tutorials refer to the home directory as the "Ubuntu home directory," this changes those references to just "home directory"

I'm assuming this is an artifact from copying from the WSL tutorials