### PR TITLE
Automate VS Code Configuration

### DIFF
--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -25,8 +25,8 @@ Importing the EECS 280 VS Code Extension:
 
     [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
 
-4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
-5. Select "EECS 280: Verify Setup"
+4. Press `Cmd+Shift+P` to open the command palette
+5. Type and select "EECS 280: Verify Setup"
 6. Follow any prompts in the terminal.
 
 If the script finds issues, it will explain each one and offer to fix it.

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -16,22 +16,6 @@ This tutorial is specific to macOS.  Looking for the [Windows version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
-## [Experimental] Install VSCode Extension
-
-Importing the EECS 280 VS Code Extension:
-
-1. Download and install VS Code if you haven't already.
-2. Install the extension
-
-    [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
-
-4. Press `Cmd+Shift+P` to open the command palette
-5. Type and select "EECS 280: Verify Setup"
-6. Follow any prompts in the terminal.
-
-If the script finds issues, it will explain each one and offer to fix it.
-After fixes are applied, close your terminal and re-run the task to confirm everything passes.
-
 ## Prerequisites
 1. VS Code relies on external command line tools.  To install CLI tools, follow the [macOS command line tools tutorial](setup_macos.html).
 
@@ -62,6 +46,14 @@ Open VS Code. You can find it in your applications (look for "Visual Studio Code
 ```console
 $ code
 ```
+
+### One-Click Setup (experimental)
+
+Click to install the EECS 280 extension: [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/eecs280.setup280)
+
+Verification runs automatically and prompts you to fix any issues it finds.  The extension installs the C/C++ and CodeLLDB extensions and disables AI features for you, so if everything passes you can skip to [Create a project](#create-a-project).
+
+If you'd rather learn how VS Code works, follow the manual instructions below, which produce the same result.
 
 ### Disable AI Features
 VS Code includes some AI-assisted coding tools (e.g. Copilot) by default. Disable these for your work in EECS 280 - using these tools for course projects is against the EECS 280 [Generative AI Policy](https://eecs280.org/syllabus.html#generative-ai-policy), and using AI as you're learning to write code prevents you from developing your own foundational programming skills.

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -16,6 +16,20 @@ This tutorial is specific to macOS.  Looking for the [Windows version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
+## [Experimental] Install VSCode Profile
+
+Importing the EECS 280 VS Code Profile:
+
+1. Download and install VS Code if you haven't already.
+2. Paste this URL: `https://vscode.dev/profile/github/370c961f7a6bc3905371824b7145a761`
+3. Click "Create Profile in Visual Studio Code" and confirm.
+4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
+5. Select "EECS 280: Verify Setup"
+6. Follow any prompts in the terminal.
+
+If the script finds issues, it will explain each one and offer to fix it.
+After fixes are applied, close your terminal and re-run the task to confirm everything passes.
+
 ## Prerequisites
 1. VS Code relies on external command line tools.  To install CLI tools, follow the [macOS command line tools tutorial](setup_macos.html).
 

--- a/docs/setup_vscode_macos.md
+++ b/docs/setup_vscode_macos.md
@@ -16,13 +16,15 @@ This tutorial is specific to macOS.  Looking for the [Windows version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
-## [Experimental] Install VSCode Profile
+## [Experimental] Install VSCode Extension
 
-Importing the EECS 280 VS Code Profile:
+Importing the EECS 280 VS Code Extension:
 
 1. Download and install VS Code if you haven't already.
-2. Paste this URL: `https://vscode.dev/profile/github/370c961f7a6bc3905371824b7145a761`
-3. Click "Create Profile in Visual Studio Code" and confirm.
+2. Install the extension
+
+    [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
+
 4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
 5. Select "EECS 280: Verify Setup"
 6. Follow any prompts in the terminal.

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -17,22 +17,6 @@ This tutorial is specific to Windows.  Looking for the [macOS version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
-## [Experimental] Install VSCode Extension
-
-Importing the EECS 280 VS Code Extension:
-
-1. Download and install VS Code if you haven't already.
-2. Ensure you open VSCode in WSL (this step needs to have an image I think)
-2. Install the extension
-
-    [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
-
-4. Press `Ctrl+Shift+P` to open the command palette 
-5. Type and select "EECS 280: Verify Setup"
-6. Follow any prompts in the terminal.
-
-If the script finds issues, it will explain each one and offer to fix it.
-After fixes are applied, close your terminal and re-run the task to confirm everything passes.
 ## Prerequisites
 
 1. Complete the [WSL tutorial](setup_wsl.html) to ensure your Windows and WSL installations are up-to-date and you have CLI tools installed.
@@ -58,6 +42,14 @@ Select each of the options below during installation.
 Open VS Code. You can skip the welcome screen.
 
 <img src="images/vscode_wsl_007.png" width="768px" />
+
+### One-Click Setup (experimental)
+
+Click to install the EECS 280 extension: [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/eecs280.setup280)
+
+Verification runs automatically and prompts you to fix any issues it finds.  The extension installs the WSL and C/C++ extensions, connects VS Code to WSL, and disables AI features for you, so if everything passes you can skip to [Create a project](#create-a-project).
+
+If you'd rather learn how VS Code works, follow the manual instructions below, which produce the same result.
 
 ### Disable AI Features
 VS Code includes some AI-assisted coding tools (e.g. Copilot) by default. Disable these for your work in EECS 280 - using these tools for course projects is against the EECS 280 [Generative AI Policy](https://eecs280.org/syllabus.html#generative-ai-policy), and using AI as you're learning to write code prevents you from developing your own foundational programming skills.

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -17,20 +17,22 @@ This tutorial is specific to Windows.  Looking for the [macOS version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
-## [Experimental] Install VSCode Profile
+## [Experimental] Install VSCode Extension
 
-Importing the EECS 280 VS Code Profile:
+Importing the EECS 280 VS Code Extension:
 
 1. Download and install VS Code if you haven't already.
-2. Paste this URL: `https://vscode.dev/profile/github/5b86cc5748cbc5b79b0bb9e4d2801298`
-3. Click "Create Profile in Visual Studio Code" and confirm.
+2. Ensure you open VSCode in WSL (this step needs to have an image I think)
+2. Install the extension
+
+    [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
+
 4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
 5. Select "EECS 280: Verify Setup"
 6. Follow any prompts in the terminal.
 
 If the script finds issues, it will explain each one and offer to fix it.
 After fixes are applied, close your terminal and re-run the task to confirm everything passes.
-
 ## Prerequisites
 
 1. Complete the [WSL tutorial](setup_wsl.html) to ensure your Windows and WSL installations are up-to-date and you have CLI tools installed.

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -27,8 +27,8 @@ Importing the EECS 280 VS Code Extension:
 
     [![Install Extension](https://img.shields.io/badge/Visual%20Studio%20Code-007ACC)](vscode:extension/kyukibug.eecs280-setup)
 
-4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
-5. Select "EECS 280: Verify Setup"
+4. Press `Ctrl+Shift+P` to open the command palette 
+5. Type and select "EECS 280: Verify Setup"
 6. Follow any prompts in the terminal.
 
 If the script finds issues, it will explain each one and offer to fix it.

--- a/docs/setup_vscode_wsl.md
+++ b/docs/setup_vscode_wsl.md
@@ -17,6 +17,20 @@ This tutorial is specific to Windows.  Looking for the [macOS version](setup_vsc
 If you already have VS Code installed with the C/C++ extensions, skip to the [Create a project](#create-a-project) section.
 </div>
 
+## [Experimental] Install VSCode Profile
+
+Importing the EECS 280 VS Code Profile:
+
+1. Download and install VS Code if you haven't already.
+2. Paste this URL: `https://vscode.dev/profile/github/5b86cc5748cbc5b79b0bb9e4d2801298`
+3. Click "Create Profile in Visual Studio Code" and confirm.
+4. Press `Cmd+Shift+P` and type "Tasks: Run Task"
+5. Select "EECS 280: Verify Setup"
+6. Follow any prompts in the terminal.
+
+If the script finds issues, it will explain each one and offer to fix it.
+After fixes are applied, close your terminal and re-run the task to confirm everything passes.
+
 ## Prerequisites
 
 1. Complete the [WSL tutorial](setup_wsl.html) to ensure your Windows and WSL installations are up-to-date and you have CLI tools installed.


### PR DESCRIPTION
Add tutorial links to one-click VS Code configuration for EECS 280.

See the separate [repo](https://github.com/eecs280staff/vscode-setup280) for the VS Code plugin.

Closes #243, contributes to #242

I've created a VSCode Profile which:

- Contains all VSCode Extensions
- Disables AI Features
- Disables LLDB's "show disassembly" setting

And created a VSCode Task embedded within the EECS280 Profile which:

- Verifies XCode is installed
- Verifies Brew is installed
- Verifies CLI tools (tree, wget, git) are installed
- Verifies VSCode 'code' command works
- If any of these fail, the bash script offers to install it for the user.

I quickly drafted an experimental section in the EECS280 VSCode MacOS tutorial with instructions on how to get your machine verified/set up!


### TODO:

- [x] Verify this works from start to end
- [x] Verify that uname arch thingy is right
- [x] Add a check for Ubuntu version to make sure it is modern enough
- [x] Try to see if they have two ubuntus -> WSL utility that helps you ask questions about Ubuntu
- [x] Add a linux verify script
- [x] change wording in WSL tutorial to reflect CTRL+SHIFT+P
- [x] change wording in tutorials to reflect that we just open command palette