### PR TITLE
WSL2 Virtualization Check Detail

### DIFF
--- a/docs/setup_wsl.md
+++ b/docs/setup_wsl.md
@@ -229,7 +229,7 @@ Cancel by closing PowerShell, [enable virtualization](#enable-virtualization), a
 WSL2 requires virtualization support. Follow the steps below to ensure it is enabled.
 
 **Step 1**  
-Launch the task manager by pressing <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>esc</kbd>. Click on the "Performance" tab.
+Launch the task manager by pressing <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>esc</kbd>. Click on the "Performance" tab, then ensure the "CPU" panel is displayed.
 
 <img src="images/wsl110.png" width=768px>
 


### PR DESCRIPTION
This PR adds a minor detail that the CPU panel needs to be displayed for users to check that virtualization is enabled. This detail is needed for completeness - the default panel shown seems to be whichever one you were looking at the last time you had task manager open, so it's possible something else would pop up if a user had been poking around the task manager for something else in the past.